### PR TITLE
feat: Static marker for Hamiltonian + variadic operator constructors

### DIFF
--- a/crates/quspin-core/src/hamiltonian/ham.rs
+++ b/crates/quspin-core/src/hamiltonian/ham.rs
@@ -18,17 +18,18 @@ pub type CoeffFn = Arc<dyn Fn(f64) -> Complex<f64> + Send + Sync>;
 
 /// Time-dependent Hamiltonian wrapping a [`QMatrix`].
 ///
-/// The matrix is partitioned into `num_coeff` operator strings:
-/// - String `0`: the **static** part, always multiplied by coefficient `1.0`.
-/// - String `k > 0`: a time-dependent part with coefficient `coeff_fns[k-1](t)`.
+/// The matrix is partitioned into `num_coeff` operator strings.  Each string
+/// has either:
+/// - a **static** coefficient (`None`) — always multiplied by `1.0`, or
+/// - a **dynamic** coefficient (`Some(f)`) — multiplied by `f(t)`.
 ///
 /// All output methods are fixed to `Complex<f64>` regardless of the stored
 /// element type `M`.
 pub struct Hamiltonian<M: Primitive, I: Index, C: CIndex> {
     pub(crate) matrix: QMatrix<M, I, C>,
-    /// One callable per time-dependent operator string (cindex 1..num_coeff).
-    /// Length must equal `matrix.num_coeff().saturating_sub(1)`.
-    pub(crate) coeff_fns: Vec<CoeffFn>,
+    /// One entry per operator string (cindex `0..num_coeff`).
+    /// `None` = static (coefficient 1.0), `Some(f)` = time-dependent.
+    pub(crate) coeff_fns: Vec<Option<CoeffFn>>,
 }
 
 impl<M: Primitive, I: Index, C: CIndex> Hamiltonian<M, I, C> {
@@ -36,15 +37,21 @@ impl<M: Primitive, I: Index, C: CIndex> Hamiltonian<M, I, C> {
     // Constructor
     // ------------------------------------------------------------------
 
-    /// Wrap a `QMatrix` and a list of time-dependent coefficient functions.
+    /// Wrap a `QMatrix` and a list of coefficient descriptors.
+    ///
+    /// Each entry corresponds to one cindex: `None` marks a static term
+    /// (coefficient 1.0) and `Some(f)` marks a time-dependent term.
     ///
     /// # Errors
-    /// Returns `ValueError` if `coeff_fns.len() != matrix.num_coeff().saturating_sub(1)`.
-    pub fn new(matrix: QMatrix<M, I, C>, coeff_fns: Vec<CoeffFn>) -> Result<Self, QuSpinError> {
-        let expected = matrix.num_coeff().saturating_sub(1);
+    /// Returns `ValueError` if `coeff_fns.len() != matrix.num_coeff()`.
+    pub fn new(
+        matrix: QMatrix<M, I, C>,
+        coeff_fns: Vec<Option<CoeffFn>>,
+    ) -> Result<Self, QuSpinError> {
+        let expected = matrix.num_coeff();
         if coeff_fns.len() != expected {
             return Err(QuSpinError::ValueError(format!(
-                "coeff_fns.len() = {} but matrix.num_coeff() - 1 = {}",
+                "coeff_fns.len() = {} but matrix.num_coeff() = {}",
                 coeff_fns.len(),
                 expected
             )));
@@ -69,12 +76,13 @@ impl<M: Primitive, I: Index, C: CIndex> Hamiltonian<M, I, C> {
     // ------------------------------------------------------------------
 
     fn eval_coeffs(&self, time: f64) -> Vec<Complex<f64>> {
-        let mut c = Vec::with_capacity(self.matrix.num_coeff());
-        c.push(Complex::new(1.0, 0.0)); // cindex 0: static
-        for f in &self.coeff_fns {
-            c.push(f(time));
-        }
-        c
+        self.coeff_fns
+            .iter()
+            .map(|f| match f {
+                Some(f) => f(time),
+                None => Complex::new(1.0, 0.0),
+            })
+            .collect()
     }
 
     // ------------------------------------------------------------------
@@ -273,30 +281,40 @@ where
 
 /// Build merged `coeff_fns` list and per-operand cindex remapping vectors.
 ///
-/// - `cindex 0` (the static part) always maps to `0` in both operands.
-/// - Each time-dependent function (cindex > 0) is deduplicated by `Arc::ptr_eq`.
+/// - All `None` (static) entries are merged to a single cindex (always cindex 0).
+/// - Each time-dependent function (`Some(Arc)`) is deduplicated by `Arc::ptr_eq`.
 ///   Functions that are the same `Arc` share a single cindex in the result.
 fn build_merged_cindex_maps<C: CIndex>(
-    lhs_fns: &[CoeffFn],
-    rhs_fns: &[CoeffFn],
-) -> (Vec<CoeffFn>, Vec<C>, Vec<C>) {
-    let mut merged: Vec<CoeffFn> = Vec::new();
+    lhs_fns: &[Option<CoeffFn>],
+    rhs_fns: &[Option<CoeffFn>],
+) -> (Vec<Option<CoeffFn>>, Vec<C>, Vec<C>) {
+    // Slot 0 is always the static (None) slot.
+    let mut merged: Vec<Option<CoeffFn>> = vec![None];
 
-    let mut make_map = |fns: &[CoeffFn]| -> Vec<C> {
-        let mut map = vec![C::from_usize(0); fns.len() + 1]; // +1 for cindex 0
-        for (k, f) in fns.iter().enumerate() {
-            // Search for an existing merged fn that is the same Arc.
-            let new_idx = merged
-                .iter()
-                .position(|existing| Arc::ptr_eq(existing, f))
-                .map(|pos| pos + 1) // cindex is 1-based
-                .unwrap_or_else(|| {
-                    merged.push(Arc::clone(f));
-                    merged.len() // newly assigned cindex
-                });
-            map[k + 1] = C::from_usize(new_idx);
-        }
-        map
+    let mut make_map = |fns: &[Option<CoeffFn>]| -> Vec<C> {
+        fns.iter()
+            .map(|f| match f {
+                None => C::from_usize(0), // all static entries share cindex 0
+                Some(arc) => {
+                    // Search for an existing dynamic entry with the same Arc.
+                    let pos = merged.iter().enumerate().skip(1).find_map(|(i, existing)| {
+                        if let Some(existing_arc) = existing
+                            && Arc::ptr_eq(existing_arc, arc)
+                        {
+                            return Some(i);
+                        }
+                        None
+                    });
+                    match pos {
+                        Some(idx) => C::from_usize(idx),
+                        None => {
+                            merged.push(Some(Arc::clone(arc)));
+                            C::from_usize(merged.len() - 1)
+                        }
+                    }
+                }
+            })
+            .collect()
     };
 
     let lhs_map = make_map(lhs_fns);
@@ -330,7 +348,8 @@ mod tests {
     #[test]
     fn eval_coeffs_static_only() {
         let mat = xx_qmatrix();
-        let ham = Hamiltonian::new(mat, vec![]).unwrap();
+        // num_coeff=1, single static entry
+        let ham = Hamiltonian::new(mat, vec![None]).unwrap();
         let coeffs = ham.eval_coeffs(0.0);
         assert_eq!(coeffs.len(), 1);
         assert_eq!(coeffs[0], Complex::new(1.0, 0.0));
@@ -339,11 +358,8 @@ mod tests {
     #[test]
     fn eval_coeffs_with_time_fn() {
         let mat = xx_qmatrix();
-        // Build a 2-cindex QMatrix by treating the single-cindex mat as having one
-        // time-dependent fn. We can't directly create a 2-cindex mat here without
-        // building a more complex operator, so just test coeff evaluation.
-        // Use a static-only mat (num_coeff=1) with no fns.
-        let ham = Hamiltonian::new(mat, vec![]).unwrap();
+        // num_coeff=1, single static entry — time value should not matter
+        let ham = Hamiltonian::new(mat, vec![None]).unwrap();
         let c = ham.eval_coeffs(3.1);
         assert_eq!(c, vec![Complex::new(1.0, 0.0)]);
     }
@@ -351,15 +367,15 @@ mod tests {
     #[test]
     fn new_wrong_coeff_count_errors() {
         let mat = xx_qmatrix();
-        // mat has num_coeff=1, so expects 0 fns; pass 1 fn → error
+        // mat has num_coeff=1, so expects 1 entry; pass 2 → error
         let f: CoeffFn = Arc::new(|_t| Complex::new(1.0, 0.0));
-        assert!(Hamiltonian::new(mat, vec![f]).is_err());
+        assert!(Hamiltonian::new(mat, vec![None, Some(f)]).is_err());
     }
 
     #[test]
     fn dot_at_time_zero_matches_qmatrix_dot() {
         let mat = xx_qmatrix();
-        let ham = Hamiltonian::new(mat.clone(), vec![]).unwrap();
+        let ham = Hamiltonian::new(mat.clone(), vec![None]).unwrap();
 
         let input = vec![
             Complex::new(1.0, 0.0),
@@ -383,8 +399,8 @@ mod tests {
     #[test]
     fn add_two_static_hamiltonians_doubles_entries() {
         let mat = xx_qmatrix();
-        let h1 = Hamiltonian::new(mat.clone(), vec![]).unwrap();
-        let h2 = Hamiltonian::new(mat, vec![]).unwrap();
+        let h1 = Hamiltonian::new(mat.clone(), vec![None]).unwrap();
+        let h2 = Hamiltonian::new(mat, vec![None]).unwrap();
         let h = h1 + h2;
 
         // H + H should give 2*H entries
@@ -406,17 +422,14 @@ mod tests {
 
     #[test]
     fn add_shared_arc_merges_to_one_cindex() {
-        // This tests the cindex-merging logic: two Hamiltonians sharing the same
-        // Arc<fn> should produce a result with only 2 cindices (0 + shared fn),
-        // not 3.
-        // Since building multi-cindex matrices requires more setup, we verify
-        // that build_merged_cindex_maps behaves correctly.
+        // Two Hamiltonians sharing the same Arc<fn> should produce a result
+        // with only 2 cindices (static + shared fn), not 3.
         let f: CoeffFn = Arc::new(|t: f64| Complex::new(t, 0.0));
-        let fns1 = vec![Arc::clone(&f)];
-        let fns2 = vec![Arc::clone(&f)];
+        let fns1 = vec![None, Some(Arc::clone(&f))];
+        let fns2 = vec![None, Some(Arc::clone(&f))];
         let (merged, map1, map2) = build_merged_cindex_maps::<u8>(&fns1, &fns2);
-        // Both should map their fn to cindex 1
-        assert_eq!(merged.len(), 1);
+        // Static → cindex 0, shared Arc → cindex 1
+        assert_eq!(merged.len(), 2);
         assert_eq!(map1, vec![0u8, 1u8]);
         assert_eq!(map2, vec![0u8, 1u8]);
     }
@@ -425,12 +438,23 @@ mod tests {
     fn add_distinct_arcs_preserves_both_cindices() {
         let f1: CoeffFn = Arc::new(|t: f64| Complex::new(t, 0.0));
         let f2: CoeffFn = Arc::new(|t: f64| Complex::new(t * 2.0, 0.0));
-        let fns1 = vec![Arc::clone(&f1)];
-        let fns2 = vec![Arc::clone(&f2)];
+        let fns1 = vec![None, Some(Arc::clone(&f1))];
+        let fns2 = vec![None, Some(Arc::clone(&f2))];
         let (merged, map1, map2) = build_merged_cindex_maps::<u8>(&fns1, &fns2);
-        // Different Arcs → 2 merged fns, each getting a distinct cindex
-        assert_eq!(merged.len(), 2);
+        // Static → cindex 0, two distinct Arcs → cindices 1 and 2
+        assert_eq!(merged.len(), 3);
         assert_eq!(map1, vec![0u8, 1u8]);
         assert_eq!(map2, vec![0u8, 2u8]);
+    }
+
+    #[test]
+    fn add_multiple_static_entries_merge_to_one() {
+        // All None entries should map to cindex 0
+        let fns1 = vec![None, None];
+        let fns2 = vec![None, None];
+        let (merged, map1, map2) = build_merged_cindex_maps::<u8>(&fns1, &fns2);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(map1, vec![0u8, 0u8]);
+        assert_eq!(map2, vec![0u8, 0u8]);
     }
 }

--- a/crates/quspin-core/src/hamiltonian/inner.rs
+++ b/crates/quspin-core/src/hamiltonian/inner.rs
@@ -109,14 +109,14 @@ pub enum HamiltonianInner {
 
 impl HamiltonianInner {
     /// Build a `HamiltonianInner` from a type-erased `QMatrixInner` and a list
-    /// of `Send + Sync` coefficient functions (one per dynamic cindex).
+    /// of coefficient descriptors (one per cindex).
     ///
-    /// The matrix element type `M` and cindex type `C` are inferred from the
-    /// `QMatrixInner` variant; the function validates that `coeff_fns.len()`
-    /// equals `qmatrix.num_coeff() - 1`.
+    /// Each entry is `None` for a static term (coefficient 1.0) or
+    /// `Some(f)` for a time-dependent term.  The matrix element type `M` and
+    /// cindex type `C` are inferred from the `QMatrixInner` variant.
     pub fn from_qmatrix_inner(
         qmatrix: QMatrixInner,
-        coeff_fns: Vec<CoeffFn>,
+        coeff_fns: Vec<Option<CoeffFn>>,
     ) -> Result<Self, QuSpinError> {
         crate::with_qmatrix!(qmatrix, _M, _C, mat, {
             Ok(Hamiltonian::new(mat, coeff_fns)?.into_hamiltonian_inner())

--- a/crates/quspin-core/src/hamiltonian/schrodinger.rs
+++ b/crates/quspin-core/src/hamiltonian/schrodinger.rs
@@ -98,7 +98,7 @@ mod tests {
         let op = HardcoreOperator::new(terms);
         let basis = FullSpace::<u32>::new(2, 1, false);
         let mat = build_from_basis::<_, u32, f64, i64, u8, _>(&op, &basis);
-        let ham = Hamiltonian::new(mat, vec![]).unwrap();
+        let ham = Hamiltonian::new(mat, vec![None]).unwrap();
         SchrodingerEq::new(ham)
     }
 

--- a/crates/quspin-py/src/hamiltonian.rs
+++ b/crates/quspin-py/src/hamiltonian.rs
@@ -15,6 +15,25 @@ type CsrArrays<'py> = (
     Bound<'py, PyArray1<Complex64>>,
 );
 
+/// Marker type indicating a static (time-independent) coefficient.
+///
+/// Pass `Static()` in the `coeff_fns` list to mark a cindex as static
+/// (coefficient = 1.0) rather than providing a callable.
+#[pyclass(name = "Static", module = "quspin._rs", frozen)]
+pub struct PyStatic;
+
+#[pymethods]
+impl PyStatic {
+    #[new]
+    fn new() -> Self {
+        PyStatic
+    }
+
+    fn __repr__(&self) -> &str {
+        "Static"
+    }
+}
+
 /// Python-facing time-dependent Hamiltonian.
 ///
 /// Wraps a `HamiltonianInner` (from `quspin-core`) behind an `Arc` so that
@@ -35,46 +54,47 @@ pub struct PyHamiltonian {
 
 #[pymethods]
 impl PyHamiltonian {
-    /// Construct a time-dependent Hamiltonian.
+    /// Construct a Hamiltonian.
     ///
     /// Args:
     ///     qmatrix:   A `QMatrix` whose cindices encode the operator terms.
-    ///                Cindex 0 is the static part (coefficient = 1).
-    ///                Cindices 1..num_coeff are time-dependent.
-    ///     coeff_fns: A list of Python callables `f(t: float) -> complex`,
-    ///                one per dynamic cindex.  Length must equal
-    ///                `qmatrix.num_coeff - 1` (or 0 for a static Hamiltonian).
+    ///     coeff_fns: A list of length `qmatrix.num_coeff`, one entry per
+    ///                cindex.  Each entry is either `Static()` (coefficient
+    ///                is always 1.0) or a callable `f(t: float) -> complex`.
     #[new]
     #[pyo3(signature = (qmatrix, coeff_fns))]
-    fn new(_py: Python<'_>, qmatrix: &PyQMatrix, coeff_fns: Vec<PyObject>) -> PyResult<Self> {
-        let expected = qmatrix.inner.num_coeff().saturating_sub(1);
+    fn new(py: Python<'_>, qmatrix: &PyQMatrix, coeff_fns: Vec<PyObject>) -> PyResult<Self> {
+        let expected = qmatrix.inner.num_coeff();
         if coeff_fns.len() != expected {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "coeff_fns has {} entries but need {} (qmatrix.num_coeff - 1)",
+                "coeff_fns has {} entries but need {} (qmatrix.num_coeff)",
                 coeff_fns.len(),
                 expected,
             )));
         }
 
-        // Wrap each Python callable in a `Send + Sync` closure that
-        // re-acquires the GIL via `Python::with_gil` (re-entrant).
-        let rust_fns: Vec<CoeffFn> = coeff_fns
+        // Convert each entry: Static() → None, callable → Some(CoeffFn).
+        let rust_fns: Vec<Option<CoeffFn>> = coeff_fns
             .into_iter()
-            .map(|f| {
-                let arc_fn: CoeffFn = Arc::new(move |t: f64| {
-                    Python::with_gil(|py| {
-                        let result = f.call1(py, (t,)).expect("coeff_fn call failed");
-                        if let Ok(z) = result.extract::<Complex<f64>>(py) {
-                            z
-                        } else {
-                            let re: f64 = result
-                                .extract(py)
-                                .expect("coeff_fn: expected float or complex");
-                            Complex::new(re, 0.0)
-                        }
-                    })
-                });
-                arc_fn
+            .map(|obj| {
+                if obj.downcast_bound::<PyStatic>(py).is_ok() {
+                    None
+                } else {
+                    let arc_fn: CoeffFn = Arc::new(move |t: f64| {
+                        Python::with_gil(|py| {
+                            let result = obj.call1(py, (t,)).expect("coeff_fn call failed");
+                            if let Ok(z) = result.extract::<Complex<f64>>(py) {
+                                z
+                            } else {
+                                let re: f64 = result
+                                    .extract(py)
+                                    .expect("coeff_fn: expected float or complex");
+                                Complex::new(re, 0.0)
+                            }
+                        })
+                    });
+                    Some(arc_fn)
+                }
             })
             .collect();
 

--- a/crates/quspin-py/src/lib.rs
+++ b/crates/quspin-py/src/lib.rs
@@ -8,7 +8,7 @@ pub mod qmatrix;
 pub mod schrodinger;
 
 use basis::{PyBosonBasis, PyFermionBasis, PySpinBasis};
-use hamiltonian::PyHamiltonian;
+use hamiltonian::{PyHamiltonian, PyStatic};
 use operator::{PyBondOperator, PyBosonOperator, PyFermionOperator, PyPauliOperator};
 use pyo3::prelude::*;
 use qmatrix::PyQMatrix;
@@ -27,6 +27,7 @@ fn _rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFermionOperator>()?;
     // Matrix, Hamiltonian, and integrator types
     m.add_class::<PyQMatrix>()?;
+    m.add_class::<PyStatic>()?;
     m.add_class::<PyHamiltonian>()?;
     m.add_class::<PySchrodingerEq>()?;
     Ok(())

--- a/crates/quspin-py/src/operator/boson.rs
+++ b/crates/quspin-py/src/operator/boson.rs
@@ -1,13 +1,13 @@
 use crate::error::Error;
-use crate::operator::pauli::{extract_coeff, max_site_from_terms};
+use crate::operator::pauli::{Terms, extract_coeff, max_site_from_terms};
 use pyo3::prelude::*;
 use quspin_core::operator::boson::{BosonOp, BosonOpEntry, BosonOperator, BosonOperatorInner};
 use smallvec::SmallVec;
 
 /// Python-facing bosonic operator (truncated harmonic oscillator).
 ///
-/// Same `(op_str, bonds)` format as `PauliOperator`, where each bond is
-/// `[coeff, site0, site1, ...]`.
+/// Same variadic `*terms` format as `PauliOperator`, using boson op strings
+/// (`+`, `-`, `n`).  `lhss` (local Hilbert-space size) is keyword-only.
 #[pyclass(name = "BosonOperator", module = "quspin._rs")]
 pub struct PyBosonOperator {
     pub inner: BosonOperatorInner,
@@ -16,12 +16,8 @@ pub struct PyBosonOperator {
 #[pymethods]
 impl PyBosonOperator {
     #[new]
-    #[pyo3(signature = (terms, lhss))]
-    fn new(
-        py: Python<'_>,
-        terms: Vec<(String, Vec<Vec<PyObject>>)>,
-        lhss: usize,
-    ) -> PyResult<Self> {
+    #[pyo3(signature = (*terms, lhss))]
+    fn new(py: Python<'_>, terms: Terms, lhss: usize) -> PyResult<Self> {
         if lhss < 2 {
             return Err(pyo3::exceptions::PyValueError::new_err("lhss must be >= 2"));
         }
@@ -74,52 +70,56 @@ impl PyBosonOperator {
 
 fn parse_terms<C: Copy + Ord + TryFrom<usize>>(
     py: Python<'_>,
-    terms: &[(String, Vec<Vec<PyObject>>)],
+    terms: &[crate::operator::pauli::Term],
 ) -> Result<Vec<BosonOpEntry<C>>, quspin_core::error::QuSpinError>
 where
     <C as TryFrom<usize>>::Error: std::fmt::Debug,
 {
     let mut entries = Vec::new();
-    for (cindex_usize, (op_str, bonds)) in terms.iter().enumerate() {
+    for (cindex_usize, term) in terms.iter().enumerate() {
         let cindex = C::try_from(cindex_usize).map_err(|_| {
             quspin_core::error::QuSpinError::ValueError(format!(
                 "cindex {cindex_usize} out of range for chosen index type"
             ))
         })?;
-        for bond in bonds {
-            if bond.is_empty() {
-                return Err(quspin_core::error::QuSpinError::ValueError(
-                    "each bond must be [coeff, site0, site1, ...]".to_string(),
-                ));
-            }
-            let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
-                quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
-            })?;
-            let sites: Vec<u32> = bond[1..]
-                .iter()
-                .map(|s| {
-                    s.bind(py).extract::<u32>().map_err(|e| {
-                        quspin_core::error::QuSpinError::ValueError(format!("bond site index: {e}"))
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-            if op_str.len() != sites.len() {
-                return Err(quspin_core::error::QuSpinError::ValueError(format!(
-                    "op_str length {} != number of sites {}",
-                    op_str.len(),
-                    sites.len()
-                )));
-            }
-            let mut ops: SmallVec<[(BosonOp, u32); 4]> = SmallVec::new();
-            for (ch, &site) in op_str.chars().zip(sites.iter()) {
-                let op = BosonOp::from_char(ch).ok_or_else(|| {
-                    quspin_core::error::QuSpinError::ValueError(format!(
-                        "unknown operator character '{ch}'; expected one of +, -, n"
-                    ))
+        for (op_str, bonds) in term {
+            for bond in bonds {
+                if bond.is_empty() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(
+                        "each bond must be [coeff, site0, site1, ...]".to_string(),
+                    ));
+                }
+                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
+                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
                 })?;
-                ops.push((op, site));
+                let sites: Vec<u32> = bond[1..]
+                    .iter()
+                    .map(|s| {
+                        s.bind(py).extract::<u32>().map_err(|e| {
+                            quspin_core::error::QuSpinError::ValueError(format!(
+                                "bond site index: {e}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                if op_str.len() != sites.len() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
+                        "op_str length {} != number of sites {}",
+                        op_str.len(),
+                        sites.len()
+                    )));
+                }
+                let mut ops: SmallVec<[(BosonOp, u32); 4]> = SmallVec::new();
+                for (ch, &site) in op_str.chars().zip(sites.iter()) {
+                    let op = BosonOp::from_char(ch).ok_or_else(|| {
+                        quspin_core::error::QuSpinError::ValueError(format!(
+                            "unknown operator character '{ch}'; expected one of +, -, n"
+                        ))
+                    })?;
+                    ops.push((op, site));
+                }
+                entries.push(BosonOpEntry::new(cindex, coeff, ops));
             }
-            entries.push(BosonOpEntry::new(cindex, coeff, ops));
         }
     }
     Ok(entries)

--- a/crates/quspin-py/src/operator/fermion.rs
+++ b/crates/quspin-py/src/operator/fermion.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::operator::pauli::{extract_coeff, max_site_from_terms};
+use crate::operator::pauli::{Terms, extract_coeff, max_site_from_terms};
 use pyo3::prelude::*;
 use quspin_core::operator::fermion::{
     FermionOp, FermionOpEntry, FermionOperator, FermionOperatorInner,
@@ -8,8 +8,8 @@ use smallvec::SmallVec;
 
 /// Python-facing fermionic operator.
 ///
-/// Same `(op_str, bonds)` format as `PauliOperator`, where each bond is
-/// `[coeff, site0, site1, ...]`.  Jordan-Wigner signs are handled automatically.
+/// Same variadic `*terms` format as `PauliOperator`, using fermion op strings
+/// (`+`, `-`, `n`).  Jordan-Wigner signs are handled automatically.
 #[pyclass(name = "FermionOperator", module = "quspin._rs")]
 pub struct PyFermionOperator {
     pub inner: FermionOperatorInner,
@@ -18,8 +18,8 @@ pub struct PyFermionOperator {
 #[pymethods]
 impl PyFermionOperator {
     #[new]
-    #[pyo3(signature = (terms))]
-    fn new(py: Python<'_>, terms: Vec<(String, Vec<Vec<PyObject>>)>) -> PyResult<Self> {
+    #[pyo3(signature = (*terms))]
+    fn new(py: Python<'_>, terms: Terms) -> PyResult<Self> {
         let max_cindex = terms.len().saturating_sub(1);
         let max_site = max_site_from_terms(py, &terms)?;
 
@@ -68,52 +68,56 @@ impl PyFermionOperator {
 
 fn parse_terms<C: Copy + Ord + TryFrom<usize>>(
     py: Python<'_>,
-    terms: &[(String, Vec<Vec<PyObject>>)],
+    terms: &[crate::operator::pauli::Term],
 ) -> Result<Vec<FermionOpEntry<C>>, quspin_core::error::QuSpinError>
 where
     <C as TryFrom<usize>>::Error: std::fmt::Debug,
 {
     let mut entries = Vec::new();
-    for (cindex_usize, (op_str, bonds)) in terms.iter().enumerate() {
+    for (cindex_usize, term) in terms.iter().enumerate() {
         let cindex = C::try_from(cindex_usize).map_err(|_| {
             quspin_core::error::QuSpinError::ValueError(format!(
                 "cindex {cindex_usize} out of range for chosen index type"
             ))
         })?;
-        for bond in bonds {
-            if bond.is_empty() {
-                return Err(quspin_core::error::QuSpinError::ValueError(
-                    "each bond must be [coeff, site0, site1, ...]".to_string(),
-                ));
-            }
-            let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
-                quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
-            })?;
-            let sites: Vec<u32> = bond[1..]
-                .iter()
-                .map(|s| {
-                    s.bind(py).extract::<u32>().map_err(|e| {
-                        quspin_core::error::QuSpinError::ValueError(format!("bond site index: {e}"))
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-            if op_str.len() != sites.len() {
-                return Err(quspin_core::error::QuSpinError::ValueError(format!(
-                    "op_str length {} != number of sites {}",
-                    op_str.len(),
-                    sites.len()
-                )));
-            }
-            let mut ops: SmallVec<[(FermionOp, u32); 4]> = SmallVec::new();
-            for (ch, &site) in op_str.chars().zip(sites.iter()) {
-                let op = FermionOp::from_char(ch).ok_or_else(|| {
-                    quspin_core::error::QuSpinError::ValueError(format!(
-                        "unknown operator character '{ch}'; expected one of +, -, n"
-                    ))
+        for (op_str, bonds) in term {
+            for bond in bonds {
+                if bond.is_empty() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(
+                        "each bond must be [coeff, site0, site1, ...]".to_string(),
+                    ));
+                }
+                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
+                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
                 })?;
-                ops.push((op, site));
+                let sites: Vec<u32> = bond[1..]
+                    .iter()
+                    .map(|s| {
+                        s.bind(py).extract::<u32>().map_err(|e| {
+                            quspin_core::error::QuSpinError::ValueError(format!(
+                                "bond site index: {e}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                if op_str.len() != sites.len() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
+                        "op_str length {} != number of sites {}",
+                        op_str.len(),
+                        sites.len()
+                    )));
+                }
+                let mut ops: SmallVec<[(FermionOp, u32); 4]> = SmallVec::new();
+                for (ch, &site) in op_str.chars().zip(sites.iter()) {
+                    let op = FermionOp::from_char(ch).ok_or_else(|| {
+                        quspin_core::error::QuSpinError::ValueError(format!(
+                            "unknown operator character '{ch}'; expected one of +, -, n"
+                        ))
+                    })?;
+                    ops.push((op, site));
+                }
+                entries.push(FermionOpEntry::new(cindex, coeff, ops));
             }
-            entries.push(FermionOpEntry::new(cindex, coeff, ops));
         }
     }
     Ok(entries)

--- a/crates/quspin-py/src/operator/pauli.rs
+++ b/crates/quspin-py/src/operator/pauli.rs
@@ -4,18 +4,25 @@ use pyo3::prelude::*;
 use quspin_core::operator::pauli::{HardcoreOp, HardcoreOperator, HardcoreOperatorInner, OpEntry};
 use smallvec::SmallVec;
 
+/// A single term: a list of `(op_str, bonds)` pairs sharing one cindex.
+pub(crate) type Term = Vec<(String, Vec<Vec<PyObject>>)>;
+/// All terms passed to a constructor (one per cindex).
+pub(crate) type Terms = Vec<Term>;
+
 /// Python-facing Pauli / hardcore-boson / spin-½ operator.
 ///
-/// Terms are grouped by coupling-constant index (cindex): the i-th element of
-/// `terms` corresponds to cindex `i`.  Each element is a `(op_str, bonds)`
-/// pair where each bond is `[coeff, site0, site1, ...]`.
+/// Each positional argument is a *term* (sharing one coupling-constant index).
+/// A term is a list of `(op_str, bonds)` pairs.  Each bond is
+/// `[coeff, site0, site1, ...]`.
 ///
-/// Example (XX + ZZ nearest-neighbour chain on 4 sites):
+/// Example (XX + ZZ nearest-neighbour chain on 4 sites, two separate terms):
 /// ```python
-/// op = PauliOperator([
-///     ("XX", [[1.0, 0, 1], [1.0, 1, 2], [1.0, 2, 3]]),
-///     ("ZZ", [[1.0, 0, 1], [1.0, 1, 2], [1.0, 2, 3]]),
-/// ])
+/// bonds = [[1.0, 0, 1], [1.0, 1, 2], [1.0, 2, 3]]
+/// # Two cindices — XX and ZZ can have independent coefficients:
+/// op = PauliOperator([("XX", bonds)], [("ZZ", bonds)])
+///
+/// # One cindex — XX and ZZ always share the same coefficient:
+/// op = PauliOperator([("XX", bonds), ("ZZ", bonds)])
 /// ```
 #[pyclass(name = "PauliOperator", module = "quspin._rs")]
 pub struct PyPauliOperator {
@@ -24,13 +31,13 @@ pub struct PyPauliOperator {
 
 #[pymethods]
 impl PyPauliOperator {
-    /// Construct from a list of `(op_str, bonds)` pairs, one per cindex.
+    /// Construct from one or more terms (variadic).
     ///
-    /// Each bond is `[coeff, site0, site1, ...]` where `coeff` is a complex
-    /// scalar and the remaining elements are integer site indices.
+    /// Each positional argument is a list of `(op_str, bonds)` pairs that
+    /// share the same cindex.  Each bond is `[coeff, site0, site1, ...]`.
     #[new]
-    #[pyo3(signature = (terms))]
-    fn new(py: Python<'_>, terms: Vec<(String, Vec<Vec<PyObject>>)>) -> PyResult<Self> {
+    #[pyo3(signature = (*terms))]
+    fn new(py: Python<'_>, terms: Terms) -> PyResult<Self> {
         let max_cindex = terms.len().saturating_sub(1);
         let max_site = max_site_from_terms(py, &terms)?;
 
@@ -82,17 +89,16 @@ impl PyPauliOperator {
 // ---------------------------------------------------------------------------
 
 /// Extract the max site index from all bonds across all terms.
-pub(crate) fn max_site_from_terms(
-    py: Python<'_>,
-    terms: &[(String, Vec<Vec<PyObject>>)],
-) -> PyResult<usize> {
+pub(crate) fn max_site_from_terms(py: Python<'_>, terms: &[Term]) -> PyResult<usize> {
     let mut max = 0usize;
-    for (_, bonds) in terms {
-        for bond in bonds {
-            // bond = [coeff, site0, site1, ...]  — skip index 0 (coeff)
-            for obj in bond.iter().skip(1) {
-                let site: u32 = obj.bind(py).extract()?;
-                max = max.max(site as usize);
+    for term in terms {
+        for (_, bonds) in term {
+            for bond in bonds {
+                // bond = [coeff, site0, site1, ...]  — skip index 0 (coeff)
+                for obj in bond.iter().skip(1) {
+                    let site: u32 = obj.bind(py).extract()?;
+                    max = max.max(site as usize);
+                }
             }
         }
     }
@@ -111,52 +117,56 @@ pub(crate) fn extract_coeff(py: Python<'_>, obj: &PyObject) -> PyResult<Complex<
 
 fn parse_terms<C: Copy + Ord + TryFrom<usize>>(
     py: Python<'_>,
-    terms: &[(String, Vec<Vec<PyObject>>)],
+    terms: &[Term],
 ) -> Result<Vec<OpEntry<C>>, quspin_core::error::QuSpinError>
 where
     <C as TryFrom<usize>>::Error: std::fmt::Debug,
 {
     let mut entries = Vec::new();
-    for (cindex_usize, (op_str, bonds)) in terms.iter().enumerate() {
+    for (cindex_usize, term) in terms.iter().enumerate() {
         let cindex = C::try_from(cindex_usize).map_err(|_| {
             quspin_core::error::QuSpinError::ValueError(format!(
                 "cindex {cindex_usize} out of range for chosen index type"
             ))
         })?;
-        for bond in bonds {
-            if bond.is_empty() {
-                return Err(quspin_core::error::QuSpinError::ValueError(
-                    "each bond must be [coeff, site0, site1, ...]".to_string(),
-                ));
-            }
-            let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
-                quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
-            })?;
-            let sites: Vec<u32> = bond[1..]
-                .iter()
-                .map(|s| {
-                    s.bind(py).extract::<u32>().map_err(|e| {
-                        quspin_core::error::QuSpinError::ValueError(format!("bond site index: {e}"))
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-            if op_str.len() != sites.len() {
-                return Err(quspin_core::error::QuSpinError::ValueError(format!(
-                    "op_str length {} != number of sites {}",
-                    op_str.len(),
-                    sites.len()
-                )));
-            }
-            let mut ops: SmallVec<[(HardcoreOp, u32); 4]> = SmallVec::new();
-            for (ch, &site) in op_str.chars().zip(sites.iter()) {
-                let op = HardcoreOp::from_char(ch).ok_or_else(|| {
-                    quspin_core::error::QuSpinError::ValueError(format!(
-                        "unknown operator character '{ch}'; expected one of x, y, z, +, -, n"
-                    ))
+        for (op_str, bonds) in term {
+            for bond in bonds {
+                if bond.is_empty() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(
+                        "each bond must be [coeff, site0, site1, ...]".to_string(),
+                    ));
+                }
+                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
+                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
                 })?;
-                ops.push((op, site));
+                let sites: Vec<u32> = bond[1..]
+                    .iter()
+                    .map(|s| {
+                        s.bind(py).extract::<u32>().map_err(|e| {
+                            quspin_core::error::QuSpinError::ValueError(format!(
+                                "bond site index: {e}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                if op_str.len() != sites.len() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
+                        "op_str length {} != number of sites {}",
+                        op_str.len(),
+                        sites.len()
+                    )));
+                }
+                let mut ops: SmallVec<[(HardcoreOp, u32); 4]> = SmallVec::new();
+                for (ch, &site) in op_str.chars().zip(sites.iter()) {
+                    let op = HardcoreOp::from_char(ch).ok_or_else(|| {
+                        quspin_core::error::QuSpinError::ValueError(format!(
+                            "unknown operator character '{ch}'; expected one of x, y, z, +, -, n"
+                        ))
+                    })?;
+                    ops.push((op, site));
+                }
+                entries.push(OpEntry::new(cindex, coeff, ops));
             }
-            entries.push(OpEntry::new(cindex, coeff, ops));
         }
     }
     Ok(entries)

--- a/crates/quspin-py/src/qmatrix.rs
+++ b/crates/quspin-py/src/qmatrix.rs
@@ -140,15 +140,21 @@ impl PyQMatrix {
     }
 
     #[getter]
+    fn num_coeff(&self) -> usize {
+        self.inner.num_coeff()
+    }
+
+    #[getter]
     fn dtype(&self) -> &str {
         self.inner.dtype_name()
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "QMatrix(dim={}, nnz={}, dtype={})",
+            "QMatrix(dim={}, nnz={}, num_coeff={}, dtype={})",
             self.inner.dim(),
             self.inner.nnz(),
+            self.inner.num_coeff(),
             self.inner.dtype_name(),
         )
     }

--- a/python/quspin_rs/__init__.py
+++ b/python/quspin_rs/__init__.py
@@ -16,6 +16,7 @@ from quspin_rs._rs import (
     QMatrix,
     SchrodingerEq,
     SpinBasis,
+    Static,
 )
 
 __all__ = [
@@ -29,4 +30,5 @@ __all__ = [
     "QMatrix",
     "SchrodingerEq",
     "SpinBasis",
+    "Static",
 ]

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -286,6 +286,8 @@ class QMatrix:
     @property
     def nnz(self) -> int: ...
     @property
+    def num_coeff(self) -> int: ...
+    @property
     def dtype(self) -> str: ...
     def __add__(self, rhs: QMatrix) -> QMatrix: ...
     def __sub__(self, rhs: QMatrix) -> QMatrix: ...
@@ -331,25 +333,41 @@ class QMatrix:
     def __repr__(self) -> str: ...
 
 # ---------------------------------------------------------------------------
+# Static marker
+# ---------------------------------------------------------------------------
+
+class Static:
+    """Marker indicating a static (time-independent) coefficient.
+
+    Pass ``Static()`` in the ``coeff_fns`` list to mark a cindex as having
+    a constant coefficient of 1.0.
+    """
+
+    def __init__(self) -> None: ...
+    def __repr__(self) -> str: ...
+
+# ---------------------------------------------------------------------------
 # Hamiltonian
 # ---------------------------------------------------------------------------
 
 class Hamiltonian:
     """Time-dependent Hamiltonian.
 
-    Wraps a ``QMatrix`` together with Python callables — one per dynamic
-    coupling constant.  Cindex 0 is always the static part (coefficient 1).
+    Wraps a ``QMatrix`` together with coefficient descriptors — one per
+    cindex.  Each entry is either ``Static()`` (coefficient 1.0) or a
+    callable ``f(t) -> complex``.
 
     Args:
         qmatrix:   A ``QMatrix`` with ``num_coeff`` operator strings.
-        coeff_fns: List of callables ``f(t: float) -> complex``, length
-                   ``qmatrix.num_coeff - 1``.
+        coeff_fns: List of length ``qmatrix.num_coeff``.  Each element is
+                   ``Static()`` for a time-independent term or a callable
+                   ``f(t: float) -> complex`` for a time-dependent term.
     """
 
     def __init__(
         self,
         qmatrix: QMatrix,
-        coeff_fns: list[Callable[[float], complex]],
+        coeff_fns: list[Static | Callable[[float], complex]],
     ) -> None: ...
     @property
     def dim(self) -> int: ...

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -147,20 +147,22 @@ class BosonBasis:
 class PauliOperator:
     """Pauli / hardcore-boson operator.
 
-    Args:
-        terms: List of ``(op_str, bonds)`` pairs, one per coupling-constant
-               index (cindex).  The i-th element corresponds to cindex ``i``.
-               Each bond is ``[coeff, site0, site1, ...]``.
+    Each positional argument is a *term* (one coupling-constant index).
+    A term is a list of ``(op_str, bonds)`` pairs that share that cindex.
+    Each bond is ``[coeff, site0, site1, ...]``.
 
     Example::
 
         bonds = [[1.0, 0, 1], [1.0, 1, 2], [1.0, 2, 3]]
+        # Two cindices (XX and ZZ can have independent coefficients):
+        op = PauliOperator([("XX", bonds)], [("ZZ", bonds)])
+        # One cindex (XX and ZZ always share the same coefficient):
         op = PauliOperator([("XX", bonds), ("ZZ", bonds)])
     """
 
     def __init__(
         self,
-        terms: list[tuple[str, list[list[Any]]]],
+        *terms: list[tuple[str, list[list[Any]]]],
     ) -> None: ...
     @property
     def max_site(self) -> int: ...
@@ -195,15 +197,13 @@ class BondOperator:
 class BosonOperator:
     """Bosonic operator.
 
-    Args:
-        terms: Same ``(op_str, bonds)`` format as ``PauliOperator``, using
-               boson op strings (``+``, ``-``, ``n``).
-        lhss:  Local Hilbert-space size.
+    Same variadic ``*terms`` format as ``PauliOperator``, using boson op
+    strings (``+``, ``-``, ``n``).  ``lhss`` is keyword-only.
     """
 
     def __init__(
         self,
-        terms: list[tuple[str, list[list[Any]]]],
+        *terms: list[tuple[str, list[list[Any]]]],
         lhss: int,
     ) -> None: ...
     @property
@@ -217,15 +217,14 @@ class BosonOperator:
 class FermionOperator:
     """Fermionic operator.
 
-    Args:
-        terms: Same ``(op_str, bonds)`` format as ``PauliOperator``, using
-               fermion op strings (``+``, ``-``, ``n``).  Jordan-Wigner signs
-               are applied automatically.
+    Same variadic ``*terms`` format as ``PauliOperator``, using fermion op
+    strings (``+``, ``-``, ``n``).  Jordan-Wigner signs are applied
+    automatically.
     """
 
     def __init__(
         self,
-        terms: list[tuple[str, list[list[Any]]]],
+        *terms: list[tuple[str, list[list[Any]]]],
     ) -> None: ...
     @property
     def max_site(self) -> int: ...

--- a/python/tests/test_rs.py
+++ b/python/tests/test_rs.py
@@ -29,7 +29,7 @@ N = 4  # number of sites
 def make_pauli_op() -> PauliOperator:
     """XX + ZZ nearest-neighbour Hamiltonian on N sites."""
     bonds = [[1.0, i, i + 1] for i in range(N - 1)]
-    return PauliOperator([("XX", bonds), ("ZZ", bonds)])
+    return PauliOperator([("XX", bonds)], [("ZZ", bonds)])
 
 
 def make_spin_basis_full() -> SpinBasis:
@@ -251,7 +251,7 @@ N_B = 3
 
 def make_boson_op() -> BosonOperator:
     bonds = [[1.0, i, i + 1] for i in range(N_B - 1)]
-    return BosonOperator([("+-", bonds), ("-+", bonds)], LHSS_B)
+    return BosonOperator([("+-", bonds)], [("-+", bonds)], lhss=LHSS_B)
 
 
 class TestBosonBasisFull:
@@ -283,7 +283,7 @@ class TestBosonBasisLargeNSites:
             [1.0, i + 1, i] for i in range(n - 1)
         ]
 
-        return BosonOperator([("+-", terms)], lhss)
+        return BosonOperator([("+-", terms)], lhss=lhss)
 
     @pytest.mark.parametrize("N", [32, 63, 64, 65, 100, 128, 200])
     def test_single_particle_basis(self, N: int):
@@ -379,7 +379,7 @@ class TestHamiltonian:
 
     def test_time_dependent_coeff(self):
         """Scaling coupling by cos(t) should give cos(t) * static result."""
-        op = PauliOperator([("ZZ", [[1.0, 0, 1]]), ("ZZ", [[1.0, 0, 1]])])
+        op = PauliOperator([("ZZ", [[1.0, 0, 1]])], [("ZZ", [[1.0, 0, 1]])])
         basis = SpinBasis.full(2)
         mat = QMatrix.build_pauli(op, basis, np.dtype("complex128"))
         ham = Hamiltonian(mat, [Static(), lambda t: math.cos(t) + 0j])
@@ -540,7 +540,7 @@ def _make_pbc_hopping_op(L: int) -> PauliOperator:
     """Single-particle XX+YY hopping on L sites with periodic boundary conditions."""
     xx_bonds = [[1.0, i, (i + 1) % L] for i in range(L)]
     yy_bonds = [[1.0, i, (i + 1) % L] for i in range(L)]
-    return PauliOperator([("XX", xx_bonds), ("YY", yy_bonds)])
+    return PauliOperator([("XX", xx_bonds)], [("YY", yy_bonds)])
 
 
 def _translation_group(

--- a/python/tests/test_rs.py
+++ b/python/tests/test_rs.py
@@ -16,6 +16,7 @@ from quspin_rs._rs import (
     QMatrix,
     SchrodingerEq,
     SpinBasis,
+    Static,
 )
 
 # ---------------------------------------------------------------------------
@@ -336,11 +337,11 @@ class TestQMatrixFermion:
 
 class TestHamiltonian:
     def _make_static(self):
-        """Static Hamiltonian: XX+ZZ — cindex 1 (ZZ) has constant coefficient 1."""
+        """Static Hamiltonian: XX+ZZ — both cindices are Static."""
         op = make_pauli_op()
         basis = make_spin_basis_full()
         mat = QMatrix.build_pauli(op, basis, np.dtype("complex128"))
-        return Hamiltonian(mat, [lambda t: 1.0 + 0j])
+        return Hamiltonian(mat, [Static(), Static()])
 
     def test_dim(self):
         h = self._make_static()
@@ -354,7 +355,7 @@ class TestHamiltonian:
         op = make_pauli_op()
         basis = make_spin_basis_full()
         mat = QMatrix.build_pauli(op, basis, np.dtype("complex128"))
-        ham = Hamiltonian(mat, [lambda t: 1.0 + 0j])
+        ham = Hamiltonian(mat, [Static(), Static()])
         coeff = np.array([1.0 + 0j, 1.0 + 0j], dtype=np.complex128)
         ip, ii, id_ = mat.to_csr(coeff)
         hp, hi, hd = ham.to_csr(0.0)
@@ -366,7 +367,7 @@ class TestHamiltonian:
         op = make_pauli_op()
         basis = make_spin_basis_full()
         mat = QMatrix.build_pauli(op, basis, np.dtype("complex128"))
-        ham = Hamiltonian(mat, [lambda t: 1.0 + 0j])
+        ham = Hamiltonian(mat, [Static(), Static()])
         n = mat.dim
         coeff = np.array([1.0 + 0j, 1.0 + 0j], dtype=np.complex128)
         inp = np.random.default_rng(7).standard_normal((n, 2)) + 0j
@@ -381,8 +382,7 @@ class TestHamiltonian:
         op = PauliOperator([("ZZ", [[1.0, 0, 1]]), ("ZZ", [[1.0, 0, 1]])])
         basis = SpinBasis.full(2)
         mat = QMatrix.build_pauli(op, basis, np.dtype("complex128"))
-        # coeff_fns[0] multiplies cindex 1
-        ham = Hamiltonian(mat, [lambda t: math.cos(t) + 0j])
+        ham = Hamiltonian(mat, [Static(), lambda t: math.cos(t) + 0j])
         n = mat.dim
         inp = np.random.default_rng(8).standard_normal((n, 1)) + 0j
         out_t0 = np.zeros((n, 1), dtype=np.complex128)
@@ -407,7 +407,7 @@ class TestSchrodingerEq:
         op = PauliOperator([("X", [[1.0, 0]])])
         basis = SpinBasis.full(1)
         mat = QMatrix.build_pauli(op, basis, np.dtype("float64"))
-        ham = Hamiltonian(mat, [])
+        ham = Hamiltonian(mat, [Static()])
         return SchrodingerEq(ham)
 
     def test_dim(self):
@@ -457,7 +457,7 @@ class TestHamiltonianExpm:
         op = PauliOperator([("Z", [[1.0, 0]])])
         basis = SpinBasis.full(1)
         mat = QMatrix.build_pauli(op, basis, np.dtype("float64"))
-        return Hamiltonian(mat, [])
+        return Hamiltonian(mat, [Static()])
 
     def _ref_expm_z(self, a, f):
         """Analytically apply exp(a * diag(1, -1)) to column(s) f.
@@ -502,7 +502,7 @@ class TestHamiltonianExpm:
         op = PauliOperator([("XX", [[1.0, 0, 1]])])
         basis = SpinBasis.full(2)
         mat = QMatrix.build_pauli(op, basis, np.dtype("float64"))
-        ham = Hamiltonian(mat, [])
+        ham = Hamiltonian(mat, [Static()])
         a = -1j * math.pi / 3
         H = ham.to_dense(0.0)
         # exp(a*H) via eigendecomposition (H is Hermitian)


### PR DESCRIPTION
## Summary
- Adds a `Static` marker type so any cindex in a `Hamiltonian` can be explicitly marked as time-independent (coefficient = 1.0), removing the old convention where only cindex 0 was implicitly static
- The `Hamiltonian` constructor now takes `num_coeff` entries (one per cindex), each either `Static()` or a callable `f(t) -> complex`
- Operator constructors (`PauliOperator`, `BosonOperator`, `FermionOperator`) now accept variadic `*terms` — each positional argument is a term (one cindex) containing a list of `(op_str, bonds)` pairs, allowing multiple operator strings to share a coupling constant
- Exposes `QMatrix.num_coeff` as a Python property
- `BosonOperator`'s `lhss` parameter is now keyword-only

### New API examples
```python
from quspin_rs import Static, PauliOperator, Hamiltonian

# Operator: two cindices (independent coefficients)
op = PauliOperator([("XX", bonds)], [("ZZ", bonds)])

# Operator: one cindex (XX and ZZ share a coefficient)
op = PauliOperator([("XX", bonds), ("ZZ", bonds)])

# Hamiltonian: any cindex can be static
ham = Hamiltonian(mat, [Static(), Static()])
ham = Hamiltonian(mat, [Static(), lambda t: cos(t)])
```

## Test plan
- [x] `cargo test -p quspin-core` — 216 Rust tests pass
- [x] `uv run pytest python/tests/ -v` — 85 Python tests pass
- [x] `cargo clippy` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)