### PR TITLE
feat: Krylov subspace methods (Lanczos, FTLM, LTLM, FTLMDynamic)

### DIFF
--- a/crates/quspin-core/src/krylov/basis.rs
+++ b/crates/quspin-core/src/krylov/basis.rs
@@ -192,7 +192,11 @@ impl LanczosBasis {
 // ---------------------------------------------------------------------------
 
 /// Lightweight Lanczos result that stores only the tridiagonal coefficients
-/// and the initial vector, not the full basis.
+/// and the initial vector — O(k + dim) after construction.
+///
+/// **Note:** The `build` method temporarily allocates O(k × dim) for full
+/// re-orthogonalization during construction, then discards the basis vectors.
+/// The persistent storage is O(k + dim) (alpha, beta, and v0).
 ///
 /// Reconstructing vectors requires replaying the Lanczos recurrence with the
 /// operator, so `lin_comb` takes the operator by reference.
@@ -206,10 +210,11 @@ pub struct LanczosBasisIter {
 }
 
 impl LanczosBasisIter {
-    /// Build the tridiagonal decomposition without storing basis vectors.
+    /// Build the tridiagonal decomposition.
     ///
-    /// Same recurrence as [`LanczosBasis::build`] but discards Q after
-    /// extracting `alpha` and `beta`.
+    /// Same recurrence as [`LanczosBasis::build`] with full re-orthogonalization.
+    /// Temporarily allocates O(k × dim) for the basis vectors during construction,
+    /// then discards them — only `alpha`, `beta`, and `v0` are retained.
     pub fn build(
         matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
         v0: &[C64],

--- a/crates/quspin-core/src/krylov/basis.rs
+++ b/crates/quspin-core/src/krylov/basis.rs
@@ -1,0 +1,563 @@
+use crate::error::QuSpinError;
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/// L2 norm of a complex vector.
+fn l2_norm(v: &[C64]) -> f64 {
+    v.iter().map(|c| c.norm_sqr()).sum::<f64>().sqrt()
+}
+
+/// Inner product <a|b> = Σ conj(a_i) * b_i.
+fn inner(a: &[C64], b: &[C64]) -> C64 {
+    a.iter().zip(b.iter()).map(|(ai, bi)| ai.conj() * bi).sum()
+}
+
+// ---------------------------------------------------------------------------
+// LanczosBasis — stores all K basis vectors
+// ---------------------------------------------------------------------------
+
+/// Stored Lanczos basis with full re-orthogonalization.
+///
+/// Stores all K orthonormal basis vectors Q and the tridiagonal matrix
+/// T = Q^H · H · Q with diagonal `alpha` and off-diagonal `beta`.
+pub struct LanczosBasis {
+    /// Orthonormal basis vectors, flat row-major: q[i] lives at `[i*dim..(i+1)*dim]`.
+    q: Vec<C64>,
+    /// Diagonal of the tridiagonal matrix T (length k_actual).
+    alpha: Vec<f64>,
+    /// Off-diagonal of T (length k_actual - 1).
+    beta: Vec<f64>,
+    /// Dimension of the full Hilbert space.
+    dim: usize,
+}
+
+impl LanczosBasis {
+    /// Build a K-step Lanczos basis with full re-orthogonalization via MGS.
+    ///
+    /// # Arguments
+    /// - `matvec` — applies `H|v⟩` in-place: `matvec(input, output)` computes `output = H * input`
+    /// - `v0` — initial vector (will be normalized)
+    /// - `k` — number of Lanczos steps requested
+    ///
+    /// The actual basis may be smaller than `k` if an invariant subspace is found.
+    pub fn build(
+        matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
+        v0: &[C64],
+        k: usize,
+    ) -> Result<Self, QuSpinError> {
+        let dim = v0.len();
+        if dim == 0 {
+            return Err(QuSpinError::ValueError("v0 must be non-empty".to_string()));
+        }
+        if k == 0 {
+            return Err(QuSpinError::ValueError("k must be at least 1".to_string()));
+        }
+
+        let k = k.min(dim);
+
+        let mut q = Vec::with_capacity(k * dim);
+        let mut alpha = Vec::with_capacity(k);
+        let mut beta: Vec<f64> = Vec::with_capacity(k.saturating_sub(1));
+        let mut w = vec![C64::default(); dim];
+
+        // Normalize v0 and store as first basis vector
+        let norm0 = l2_norm(v0);
+        if norm0 < f64::EPSILON {
+            return Err(QuSpinError::ValueError("v0 has zero norm".to_string()));
+        }
+        let inv_norm0 = 1.0 / norm0;
+        q.extend(v0.iter().map(|&c| c * inv_norm0));
+
+        for j in 0..k {
+            let qj = &q[j * dim..(j + 1) * dim];
+
+            // w = H * q_j
+            matvec(qj, &mut w)?;
+
+            // Three-term recurrence: subtract projections onto q_j and q_{j-1}
+            let aj = inner(qj, &w).re; // Hermitian → real
+            alpha.push(aj);
+
+            for i in 0..dim {
+                w[i] -= C64::new(aj, 0.0) * qj[i];
+            }
+            if j > 0 {
+                let bprev = beta[j - 1];
+                let qprev = &q[(j - 1) * dim..j * dim];
+                for i in 0..dim {
+                    w[i] -= C64::new(bprev, 0.0) * qprev[i];
+                }
+            }
+
+            // Full re-orthogonalization via MGS (two passes for stability)
+            for _pass in 0..2 {
+                for l in 0..=j {
+                    let ql = &q[l * dim..(l + 1) * dim];
+                    let h = inner(ql, &w);
+                    for i in 0..dim {
+                        w[i] -= h * ql[i];
+                    }
+                }
+            }
+
+            // Compute norm for next basis vector
+            let bj = l2_norm(&w);
+
+            if j < k - 1 {
+                if bj < 1e-14 * dim as f64 {
+                    // Invariant subspace found — stop
+                    break;
+                }
+                beta.push(bj);
+                let inv_bj = 1.0 / bj;
+                q.extend(w.iter().map(|&c| c * inv_bj));
+            }
+        }
+
+        Ok(LanczosBasis {
+            q,
+            alpha,
+            beta,
+            dim,
+        })
+    }
+
+    /// Number of Lanczos vectors actually computed.
+    pub fn k(&self) -> usize {
+        self.alpha.len()
+    }
+
+    /// Dimension of the full Hilbert space.
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Diagonal of the tridiagonal matrix (length `k`).
+    pub fn alpha(&self) -> &[f64] {
+        &self.alpha
+    }
+
+    /// Off-diagonal of the tridiagonal matrix (length `k - 1`).
+    pub fn beta(&self) -> &[f64] {
+        &self.beta
+    }
+
+    /// Access the i-th basis vector.
+    pub fn q(&self, i: usize) -> &[C64] {
+        &self.q[i * self.dim..(i + 1) * self.dim]
+    }
+
+    /// Reconstruct a full-space vector from Krylov-space coefficients.
+    ///
+    /// Computes `result = Σ_j coeffs[j] * q_j` where `q_j` are the stored
+    /// basis vectors.
+    pub fn lin_comb(&self, coeffs: &[C64], result: &mut [C64]) -> Result<(), QuSpinError> {
+        let k = self.k();
+        if coeffs.len() != k {
+            return Err(QuSpinError::ValueError(format!(
+                "coeffs.len() = {} but basis has k = {}",
+                coeffs.len(),
+                k,
+            )));
+        }
+        if result.len() != self.dim {
+            return Err(QuSpinError::ValueError(format!(
+                "result.len() = {} but dim = {}",
+                result.len(),
+                self.dim,
+            )));
+        }
+
+        // Zero output
+        result.iter_mut().for_each(|c| *c = C64::default());
+
+        for (j, &cj) in coeffs.iter().enumerate() {
+            let qj = self.q(j);
+            for i in 0..self.dim {
+                result[i] += cj * qj[i];
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LanczosBasisIter — generator, O(dim) memory
+// ---------------------------------------------------------------------------
+
+/// Lightweight Lanczos result that stores only the tridiagonal coefficients
+/// and the initial vector, not the full basis.
+///
+/// Reconstructing vectors requires replaying the Lanczos recurrence with the
+/// operator, so `lin_comb` takes the operator by reference.
+pub struct LanczosBasisIter {
+    /// Normalized initial vector.
+    v0: Vec<C64>,
+    /// Diagonal of the tridiagonal matrix (length k).
+    alpha: Vec<f64>,
+    /// Off-diagonal of the tridiagonal matrix (length k - 1).
+    beta: Vec<f64>,
+}
+
+impl LanczosBasisIter {
+    /// Build the tridiagonal decomposition without storing basis vectors.
+    ///
+    /// Same recurrence as [`LanczosBasis::build`] but discards Q after
+    /// extracting `alpha` and `beta`.
+    pub fn build(
+        matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
+        v0: &[C64],
+        k: usize,
+    ) -> Result<Self, QuSpinError> {
+        let dim = v0.len();
+        if dim == 0 {
+            return Err(QuSpinError::ValueError("v0 must be non-empty".to_string()));
+        }
+        if k == 0 {
+            return Err(QuSpinError::ValueError("k must be at least 1".to_string()));
+        }
+
+        let k = k.min(dim);
+
+        let mut alpha = Vec::with_capacity(k);
+        let mut beta: Vec<f64> = Vec::with_capacity(k.saturating_sub(1));
+
+        // For full re-orthogonalization we need to keep all basis vectors
+        // during the build phase; they are discarded afterwards.
+        let mut q = Vec::with_capacity(k * dim);
+        let mut w = vec![C64::default(); dim];
+
+        let norm0 = l2_norm(v0);
+        if norm0 < f64::EPSILON {
+            return Err(QuSpinError::ValueError("v0 has zero norm".to_string()));
+        }
+        let inv_norm0 = 1.0 / norm0;
+        let v0_normed: Vec<C64> = v0.iter().map(|&c| c * inv_norm0).collect();
+        q.extend_from_slice(&v0_normed);
+
+        for j in 0..k {
+            let qj = &q[j * dim..(j + 1) * dim];
+            matvec(qj, &mut w)?;
+
+            let aj = inner(qj, &w).re;
+            alpha.push(aj);
+
+            for i in 0..dim {
+                w[i] -= C64::new(aj, 0.0) * qj[i];
+            }
+            if j > 0 {
+                let bprev = beta[j - 1];
+                let qprev = &q[(j - 1) * dim..j * dim];
+                for i in 0..dim {
+                    w[i] -= C64::new(bprev, 0.0) * qprev[i];
+                }
+            }
+
+            // Full re-orthogonalization (two passes)
+            for _pass in 0..2 {
+                for l in 0..=j {
+                    let ql = &q[l * dim..(l + 1) * dim];
+                    let h = inner(ql, &w);
+                    for i in 0..dim {
+                        w[i] -= h * ql[i];
+                    }
+                }
+            }
+
+            let bj = l2_norm(&w);
+
+            if j < k - 1 {
+                if bj < 1e-14 * dim as f64 {
+                    break;
+                }
+                beta.push(bj);
+                let inv_bj = 1.0 / bj;
+                q.extend(w.iter().map(|&c| c * inv_bj));
+            }
+        }
+
+        Ok(LanczosBasisIter {
+            v0: v0_normed,
+            alpha,
+            beta,
+        })
+    }
+
+    /// Number of Lanczos steps computed.
+    pub fn k(&self) -> usize {
+        self.alpha.len()
+    }
+
+    /// Dimension of the full Hilbert space.
+    pub fn dim(&self) -> usize {
+        self.v0.len()
+    }
+
+    /// Diagonal of the tridiagonal matrix.
+    pub fn alpha(&self) -> &[f64] {
+        &self.alpha
+    }
+
+    /// Off-diagonal of the tridiagonal matrix.
+    pub fn beta(&self) -> &[f64] {
+        &self.beta
+    }
+
+    /// Replay the Lanczos recurrence, calling `f(j, q_j)` at each step.
+    ///
+    /// This re-derives the basis vectors using the operator without storing
+    /// them all simultaneously.
+    pub fn for_each(
+        &self,
+        matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
+        mut f: impl FnMut(usize, &[C64]),
+    ) -> Result<(), QuSpinError> {
+        let dim = self.dim();
+        let k = self.k();
+
+        let mut v_prev = vec![C64::default(); dim];
+        let mut v_curr = self.v0.clone();
+        let mut w = vec![C64::default(); dim];
+
+        for j in 0..k {
+            f(j, &v_curr);
+
+            if j < k - 1 {
+                matvec(&v_curr, &mut w)?;
+
+                let aj = self.alpha[j];
+                for i in 0..dim {
+                    w[i] -= C64::new(aj, 0.0) * v_curr[i];
+                }
+                if j > 0 {
+                    let bprev = self.beta[j - 1];
+                    for i in 0..dim {
+                        w[i] -= C64::new(bprev, 0.0) * v_prev[i];
+                    }
+                }
+
+                let bj = self.beta[j];
+                let inv_bj = 1.0 / bj;
+
+                // Shift: v_prev ← v_curr, v_curr ← w / beta_j
+                std::mem::swap(&mut v_prev, &mut v_curr);
+                for i in 0..dim {
+                    v_curr[i] = w[i] * inv_bj;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reconstruct a full-space vector from Krylov-space coefficients by
+    /// replaying the recurrence.
+    ///
+    /// Computes `result = Σ_j coeffs[j] * q_j` where `q_j` are re-derived
+    /// from the stored tridiagonal coefficients and the operator.
+    pub fn lin_comb(
+        &self,
+        matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
+        coeffs: &[C64],
+        result: &mut [C64],
+    ) -> Result<(), QuSpinError> {
+        if coeffs.len() != self.k() {
+            return Err(QuSpinError::ValueError(format!(
+                "coeffs.len() = {} but basis has k = {}",
+                coeffs.len(),
+                self.k(),
+            )));
+        }
+        if result.len() != self.dim() {
+            return Err(QuSpinError::ValueError(format!(
+                "result.len() = {} but dim = {}",
+                result.len(),
+                self.dim(),
+            )));
+        }
+
+        result.iter_mut().for_each(|c| *c = C64::default());
+
+        self.for_each(matvec, |j, qj| {
+            let cj = coeffs[j];
+            for i in 0..self.dim() {
+                result[i] += cj * qj[i];
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 2×2 Pauli X matrix: H = [[0, 1], [1, 0]]
+    fn pauli_x(input: &[C64], output: &mut [C64]) -> Result<(), QuSpinError> {
+        output[0] = input[1];
+        output[1] = input[0];
+        Ok(())
+    }
+
+    /// 4×4 XX + ZZ Hamiltonian for 2-site chain.
+    ///
+    /// H = X⊗X + Z⊗Z in the {|00⟩, |01⟩, |10⟩, |11⟩} basis:
+    /// ```text
+    /// [[1, 0, 0, 1],
+    ///  [0,-1, 1, 0],
+    ///  [0, 1,-1, 0],
+    ///  [1, 0, 0, 1]]
+    /// ```
+    /// Eigenvalues: -2, 0, 0, 2
+    fn xx_zz_2site(input: &[C64], output: &mut [C64]) -> Result<(), QuSpinError> {
+        let one = C64::new(1.0, 0.0);
+        let neg = C64::new(-1.0, 0.0);
+        output[0] = one * input[0] + one * input[3];
+        output[1] = neg * input[1] + one * input[2];
+        output[2] = one * input[1] + neg * input[2];
+        output[3] = one * input[0] + one * input[3];
+        Ok(())
+    }
+
+    #[test]
+    fn basis_2x2_orthonormal() {
+        let v0 = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let basis = LanczosBasis::build(&mut pauli_x, &v0, 2).unwrap();
+
+        assert_eq!(basis.k(), 2);
+
+        // Check orthonormality
+        for i in 0..basis.k() {
+            for j in 0..basis.k() {
+                let dot = inner(basis.q(i), basis.q(j));
+                if i == j {
+                    assert!((dot.re - 1.0).abs() < 1e-12, "<q{i}|q{j}> = {dot}");
+                } else {
+                    assert!(dot.norm() < 1e-12, "<q{i}|q{j}> = {dot}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn basis_2x2_eigenvalues() {
+        let v0 = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let basis = LanczosBasis::build(&mut pauli_x, &v0, 2).unwrap();
+
+        // For Pauli X, eigenvalues are ±1.
+        // The tridiagonal matrix should reproduce these.
+        assert_eq!(basis.alpha().len(), 2);
+        assert_eq!(basis.beta().len(), 1);
+
+        // T = [[alpha[0], beta[0]], [beta[0], alpha[1]]]
+        // eigenvalues of T: alpha[0] ± beta[0] (if alpha[0] == alpha[1] == 0)
+        let a0 = basis.alpha()[0];
+        let a1 = basis.alpha()[1];
+        let b0 = basis.beta()[0];
+        let trace = a0 + a1;
+        let det = a0 * a1 - b0 * b0;
+        let disc = (trace * trace - 4.0 * det).sqrt();
+        let e1 = (trace - disc) / 2.0;
+        let e2 = (trace + disc) / 2.0;
+
+        assert!((e1 - (-1.0)).abs() < 1e-12, "e1 = {e1}, expected -1");
+        assert!((e2 - 1.0).abs() < 1e-12, "e2 = {e2}, expected 1");
+    }
+
+    #[test]
+    fn basis_4x4_eigenvalues() {
+        // Use a starting vector that spans the full space
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(1.0, 0.0),
+            C64::new(1.0, 0.0),
+            C64::new(1.0, 0.0),
+        ];
+        let basis = LanczosBasis::build(&mut xx_zz_2site, &v0, 4).unwrap();
+
+        // XX+ZZ eigenvalues: {-2, 0, 0, 2}
+        // Depending on starting vector, may not span all eigenspaces.
+        // With v0 = [1,1,1,1], we should get at least the non-degenerate eigenvalues.
+        assert!(basis.k() >= 2);
+    }
+
+    #[test]
+    fn lin_comb_stored_and_iter_agree() {
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(0.5, 0.3),
+            C64::new(-0.2, 0.1),
+            C64::new(0.0, 0.7),
+        ];
+
+        let stored = LanczosBasis::build(&mut xx_zz_2site, &v0, 4).unwrap();
+        let iter = LanczosBasisIter::build(&mut xx_zz_2site, &v0, 4).unwrap();
+
+        assert_eq!(stored.k(), iter.k());
+        assert_eq!(stored.alpha().len(), iter.alpha().len());
+        assert_eq!(stored.beta().len(), iter.beta().len());
+
+        // Check tridiagonal coefficients agree
+        for j in 0..stored.k() {
+            assert!(
+                (stored.alpha()[j] - iter.alpha()[j]).abs() < 1e-12,
+                "alpha[{j}]: stored={}, iter={}",
+                stored.alpha()[j],
+                iter.alpha()[j],
+            );
+        }
+        for j in 0..stored.beta().len() {
+            assert!(
+                (stored.beta()[j] - iter.beta()[j]).abs() < 1e-12,
+                "beta[{j}]: stored={}, iter={}",
+                stored.beta()[j],
+                iter.beta()[j],
+            );
+        }
+
+        // Test lin_comb with some arbitrary coefficients
+        let k = stored.k();
+        let coeffs: Vec<C64> = (0..k)
+            .map(|j| C64::new(j as f64 * 0.3 + 0.1, -(j as f64) * 0.2))
+            .collect();
+
+        let mut result_stored = vec![C64::default(); stored.dim()];
+        let mut result_iter = vec![C64::default(); iter.dim()];
+
+        stored.lin_comb(&coeffs, &mut result_stored).unwrap();
+        iter.lin_comb(&mut xx_zz_2site, &coeffs, &mut result_iter)
+            .unwrap();
+
+        for i in 0..stored.dim() {
+            assert!(
+                (result_stored[i] - result_iter[i]).norm() < 1e-10,
+                "result[{i}]: stored={}, iter={}",
+                result_stored[i],
+                result_iter[i],
+            );
+        }
+    }
+
+    #[test]
+    fn invariant_subspace_early_stop() {
+        // Pauli X is 2×2, so requesting k=10 should give k=2
+        let v0 = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let basis = LanczosBasis::build(&mut pauli_x, &v0, 10).unwrap();
+        assert_eq!(basis.k(), 2);
+    }
+
+    #[test]
+    fn zero_v0_errors() {
+        let v0 = vec![C64::default(); 4];
+        assert!(LanczosBasis::build(&mut xx_zz_2site, &v0, 4).is_err());
+    }
+}

--- a/crates/quspin-core/src/krylov/eig.rs
+++ b/crates/quspin-core/src/krylov/eig.rs
@@ -1,0 +1,427 @@
+use super::basis::LanczosBasis;
+use crate::error::QuSpinError;
+use nalgebra::DMatrix;
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+// ---------------------------------------------------------------------------
+// TridiagEigen — eigendecomposition of a tridiagonal matrix
+// ---------------------------------------------------------------------------
+
+/// Eigendecomposition of a real symmetric tridiagonal matrix.
+///
+/// Shared by `lanczos_eig`, FTLM, and LTLM.
+pub struct TridiagEigen {
+    /// Eigenvalues (length k).
+    pub eigenvalues: Vec<f64>,
+    /// Eigenvector matrix, column-major: element (i, j) is at `vecs[i + j * k]`.
+    /// Column j is the eigenvector for `eigenvalues[j]`.
+    pub vecs: Vec<f64>,
+    /// Dimension of the tridiagonal matrix.
+    pub k: usize,
+}
+
+impl TridiagEigen {
+    /// Element (i, j) of the eigenvector matrix.
+    pub fn vec_element(&self, i: usize, j: usize) -> f64 {
+        self.vecs[i + j * self.k]
+    }
+}
+
+/// Solve the eigenvalue problem for a real symmetric tridiagonal matrix
+/// with diagonal `alpha` and off-diagonal `beta`.
+pub fn solve_tridiagonal(alpha: &[f64], beta: &[f64]) -> TridiagEigen {
+    let k = alpha.len();
+    debug_assert_eq!(beta.len() + 1, k);
+
+    let mut t = DMatrix::<f64>::zeros(k, k);
+    for j in 0..k {
+        t[(j, j)] = alpha[j];
+    }
+    for j in 0..beta.len() {
+        t[(j, j + 1)] = beta[j];
+        t[(j + 1, j)] = beta[j];
+    }
+
+    let eigen = t.symmetric_eigen();
+
+    // Copy into flat column-major layout
+    let mut vecs = vec![0.0_f64; k * k];
+    for col in 0..k {
+        for row in 0..k {
+            vecs[row + col * k] = eigen.eigenvectors[(row, col)];
+        }
+    }
+
+    TridiagEigen {
+        eigenvalues: eigen.eigenvalues.as_slice().to_vec(),
+        vecs,
+        k,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Which — eigenvalue selection
+// ---------------------------------------------------------------------------
+
+/// Which eigenvalues to target.
+#[derive(Debug, Clone, Copy)]
+pub enum Which {
+    SmallestAlgebraic,
+    LargestAlgebraic,
+    SmallestMagnitude,
+}
+
+// ---------------------------------------------------------------------------
+// EigResult
+// ---------------------------------------------------------------------------
+
+/// Result of a Lanczos eigenvalue computation.
+pub struct EigResult {
+    /// Real eigenvalues (sorted according to the `Which` selector).
+    pub eigenvalues: Vec<f64>,
+    /// Corresponding eigenvectors in the full Hilbert space,
+    /// stored flat in row-major order: eigvec `i` is at `[i*dim..(i+1)*dim]`.
+    pub eigenvectors: Vec<C64>,
+    /// Residual norms `‖H·x - λ·x‖` for each Ritz pair.
+    pub residuals: Vec<f64>,
+    /// Dimension of the full Hilbert space.
+    dim: usize,
+}
+
+impl EigResult {
+    /// Number of converged eigenpairs returned.
+    pub fn n_eig(&self) -> usize {
+        self.eigenvalues.len()
+    }
+
+    /// Dimension of the full Hilbert space.
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Access the i-th eigenvector.
+    pub fn eigenvector(&self, i: usize) -> &[C64] {
+        &self.eigenvectors[i * self.dim..(i + 1) * self.dim]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// lanczos_eig
+// ---------------------------------------------------------------------------
+
+/// Compute eigenvalues and eigenvectors using the Lanczos algorithm.
+///
+/// # Arguments
+/// - `matvec` — applies `H|v⟩`: `matvec(input, output)` computes `output = H * input`
+/// - `v0` — initial vector (will be normalized internally)
+/// - `k_krylov` — Krylov subspace dimension
+/// - `k_wanted` — number of eigenpairs to return
+/// - `which` — eigenvalue selection criterion
+/// - `tol` — convergence tolerance on residual norms
+pub fn lanczos_eig(
+    matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
+    v0: &[C64],
+    k_krylov: usize,
+    k_wanted: usize,
+    which: Which,
+    _tol: f64,
+) -> Result<EigResult, QuSpinError> {
+    if k_wanted == 0 {
+        return Err(QuSpinError::ValueError(
+            "k_wanted must be at least 1".to_string(),
+        ));
+    }
+    if k_krylov < k_wanted {
+        return Err(QuSpinError::ValueError(format!(
+            "k_krylov ({k_krylov}) must be >= k_wanted ({k_wanted})"
+        )));
+    }
+
+    let dim = v0.len();
+
+    // Step 1: Build Lanczos basis
+    let basis = LanczosBasis::build(matvec, v0, k_krylov)?;
+    let k = basis.k();
+    let k_wanted = k_wanted.min(k);
+
+    // Step 2: Diagonalize the tridiagonal matrix
+    let eig = solve_tridiagonal(basis.alpha(), basis.beta());
+
+    // Step 3: Sort indices by the requested criterion
+    let mut indices: Vec<usize> = (0..k).collect();
+    match which {
+        Which::SmallestAlgebraic => {
+            indices.sort_by(|&a, &b| eig.eigenvalues[a].partial_cmp(&eig.eigenvalues[b]).unwrap());
+        }
+        Which::LargestAlgebraic => {
+            indices.sort_by(|&a, &b| eig.eigenvalues[b].partial_cmp(&eig.eigenvalues[a]).unwrap());
+        }
+        Which::SmallestMagnitude => {
+            indices.sort_by(|&a, &b| {
+                eig.eigenvalues[a]
+                    .abs()
+                    .partial_cmp(&eig.eigenvalues[b].abs())
+                    .unwrap()
+            });
+        }
+    }
+    indices.truncate(k_wanted);
+
+    // Step 4: Map eigenvectors back to full space and compute residuals
+    let mut eigenvalues = Vec::with_capacity(k_wanted);
+    let mut eigenvectors = Vec::with_capacity(k_wanted * dim);
+    let mut residuals = Vec::with_capacity(k_wanted);
+
+    let mut full_vec = vec![C64::default(); dim];
+    let mut h_full_vec = vec![C64::default(); dim];
+
+    for &idx in &indices {
+        let lam = eig.eigenvalues[idx];
+        eigenvalues.push(lam);
+
+        // Convert Krylov-space eigenvector to complex coefficients
+        let krylov_coeffs: Vec<C64> = (0..k)
+            .map(|j| C64::new(eig.vec_element(j, idx), 0.0))
+            .collect();
+
+        // Project back to full space: x = Q * y
+        basis.lin_comb(&krylov_coeffs, &mut full_vec)?;
+        eigenvectors.extend_from_slice(&full_vec);
+
+        // Residual: ‖H·x - λ·x‖
+        matvec(&full_vec, &mut h_full_vec)?;
+        let residual: f64 = h_full_vec
+            .iter()
+            .zip(full_vec.iter())
+            .map(|(hx, x)| (hx - C64::new(lam, 0.0) * x).norm_sqr())
+            .sum::<f64>()
+            .sqrt();
+        residuals.push(residual);
+    }
+
+    Ok(EigResult {
+        eigenvalues,
+        eigenvectors,
+        residuals,
+        dim,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 2×2 Pauli X: eigenvalues ±1.
+    fn pauli_x(input: &[C64], output: &mut [C64]) -> Result<(), QuSpinError> {
+        output[0] = input[1];
+        output[1] = input[0];
+        Ok(())
+    }
+
+    /// 4×4 XX + ZZ Hamiltonian (2-site chain).
+    /// Eigenvalues: -2, 0, 0, 2.
+    fn xx_zz_2site(input: &[C64], output: &mut [C64]) -> Result<(), QuSpinError> {
+        let one = C64::new(1.0, 0.0);
+        let neg = C64::new(-1.0, 0.0);
+        output[0] = one * input[0] + one * input[3];
+        output[1] = neg * input[1] + one * input[2];
+        output[2] = one * input[1] + neg * input[2];
+        output[3] = one * input[0] + one * input[3];
+        Ok(())
+    }
+
+    // -- solve_tridiagonal tests --
+
+    #[test]
+    fn tridiag_2x2_eigenvalues() {
+        // T = [[0, 1], [1, 0]] → eigenvalues ±1
+        let eig = solve_tridiagonal(&[0.0, 0.0], &[1.0]);
+        let mut vals: Vec<f64> = eig.eigenvalues.clone();
+        vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert!((vals[0] - (-1.0)).abs() < 1e-12);
+        assert!((vals[1] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn tridiag_eigenvectors_orthonormal() {
+        let eig = solve_tridiagonal(&[1.0, -1.0, 0.5], &[0.5, 0.3]);
+        for i in 0..eig.k {
+            for j in 0..eig.k {
+                let dot: f64 = (0..eig.k)
+                    .map(|r| eig.vec_element(r, i) * eig.vec_element(r, j))
+                    .sum();
+                if i == j {
+                    assert!((dot - 1.0).abs() < 1e-12, "⟨v{i}|v{j}⟩ = {dot}");
+                } else {
+                    assert!(dot.abs() < 1e-12, "⟨v{i}|v{j}⟩ = {dot}");
+                }
+            }
+        }
+    }
+
+    // -- lanczos_eig tests --
+
+    #[test]
+    fn pauli_x_ground_state() {
+        let v0 = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let result = lanczos_eig(&mut pauli_x, &v0, 2, 1, Which::SmallestAlgebraic, 1e-12).unwrap();
+
+        assert_eq!(result.n_eig(), 1);
+        assert!(
+            (result.eigenvalues[0] - (-1.0)).abs() < 1e-10,
+            "ground state energy = {}, expected -1",
+            result.eigenvalues[0],
+        );
+        assert!(
+            result.residuals[0] < 1e-10,
+            "residual = {}",
+            result.residuals[0],
+        );
+    }
+
+    #[test]
+    fn pauli_x_both_eigenvalues() {
+        let v0 = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let result = lanczos_eig(&mut pauli_x, &v0, 2, 2, Which::SmallestAlgebraic, 1e-12).unwrap();
+
+        assert_eq!(result.n_eig(), 2);
+        assert!(
+            (result.eigenvalues[0] - (-1.0)).abs() < 1e-10,
+            "e0 = {}",
+            result.eigenvalues[0],
+        );
+        assert!(
+            (result.eigenvalues[1] - 1.0).abs() < 1e-10,
+            "e1 = {}",
+            result.eigenvalues[1],
+        );
+    }
+
+    #[test]
+    fn xx_zz_ground_state_energy() {
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(0.5, 0.3),
+            C64::new(-0.2, 0.1),
+            C64::new(0.0, 0.7),
+        ];
+        let result =
+            lanczos_eig(&mut xx_zz_2site, &v0, 4, 1, Which::SmallestAlgebraic, 1e-12).unwrap();
+
+        assert!(
+            (result.eigenvalues[0] - (-2.0)).abs() < 1e-10,
+            "ground state energy = {}, expected -2",
+            result.eigenvalues[0],
+        );
+        assert!(
+            result.residuals[0] < 1e-10,
+            "residual = {}",
+            result.residuals[0],
+        );
+    }
+
+    #[test]
+    fn xx_zz_largest_3() {
+        // XX+ZZ has eigenvalues {-2, 0, 0, 2} but minimal polynomial is
+        // x³ - 4x (degree 3), so the Krylov subspace is 3-dimensional
+        // and finds the distinct eigenvalues {-2, 0, 2}.
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(0.5, 0.3),
+            C64::new(-0.2, 0.1),
+            C64::new(0.0, 0.7),
+        ];
+        let result =
+            lanczos_eig(&mut xx_zz_2site, &v0, 4, 3, Which::LargestAlgebraic, 1e-12).unwrap();
+
+        assert_eq!(result.n_eig(), 3);
+        // Sorted descending: 2, 0, -2
+        assert!(
+            (result.eigenvalues[0] - 2.0).abs() < 1e-10,
+            "e0 = {}",
+            result.eigenvalues[0],
+        );
+        assert!(
+            result.eigenvalues[1].abs() < 1e-10,
+            "e1 = {}, expected 0",
+            result.eigenvalues[1],
+        );
+        assert!(
+            (result.eigenvalues[2] - (-2.0)).abs() < 1e-10,
+            "e2 = {}, expected -2",
+            result.eigenvalues[2],
+        );
+    }
+
+    #[test]
+    fn smallest_magnitude() {
+        // Krylov subspace finds distinct eigenvalues {-2, 0, 2}.
+        // Smallest magnitude: 0, then ±2.
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(0.5, 0.3),
+            C64::new(-0.2, 0.1),
+            C64::new(0.0, 0.7),
+        ];
+        let result =
+            lanczos_eig(&mut xx_zz_2site, &v0, 4, 2, Which::SmallestMagnitude, 1e-12).unwrap();
+
+        assert_eq!(result.n_eig(), 2);
+        assert!(
+            result.eigenvalues[0].abs() < 1e-10,
+            "e0 = {}, expected 0",
+            result.eigenvalues[0],
+        );
+        assert!(
+            (result.eigenvalues[1].abs() - 2.0).abs() < 1e-10,
+            "e1 = {}, expected ±2",
+            result.eigenvalues[1],
+        );
+    }
+
+    #[test]
+    fn residuals_are_small() {
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(0.5, 0.3),
+            C64::new(-0.2, 0.1),
+            C64::new(0.0, 0.7),
+        ];
+        let result =
+            lanczos_eig(&mut xx_zz_2site, &v0, 4, 4, Which::SmallestAlgebraic, 1e-12).unwrap();
+
+        for (i, &r) in result.residuals.iter().enumerate() {
+            assert!(r < 1e-10, "residual[{i}] = {r}");
+        }
+    }
+
+    #[test]
+    fn eigenvectors_are_normalized() {
+        let v0 = vec![
+            C64::new(1.0, 0.0),
+            C64::new(0.5, 0.3),
+            C64::new(-0.2, 0.1),
+            C64::new(0.0, 0.7),
+        ];
+        let result =
+            lanczos_eig(&mut xx_zz_2site, &v0, 4, 4, Which::SmallestAlgebraic, 1e-12).unwrap();
+
+        for i in 0..result.n_eig() {
+            let v = result.eigenvector(i);
+            let norm: f64 = v.iter().map(|c| c.norm_sqr()).sum::<f64>().sqrt();
+            assert!((norm - 1.0).abs() < 1e-10, "eigenvector {i} norm = {norm}",);
+        }
+    }
+
+    #[test]
+    fn k_wanted_greater_than_k_krylov_errors() {
+        let v0 = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        assert!(lanczos_eig(&mut pauli_x, &v0, 1, 2, Which::SmallestAlgebraic, 1e-12).is_err());
+    }
+}

--- a/crates/quspin-core/src/krylov/eig.rs
+++ b/crates/quspin-core/src/krylov/eig.rs
@@ -119,14 +119,15 @@ impl EigResult {
 /// - `k_krylov` — Krylov subspace dimension
 /// - `k_wanted` — number of eigenpairs to return
 /// - `which` — eigenvalue selection criterion
-/// - `tol` — convergence tolerance on residual norms
+/// - `tol` — convergence tolerance on residual norms; only eigenpairs with
+///   residual `≤ tol` are returned (pass `f64::INFINITY` to disable)
 pub fn lanczos_eig(
     matvec: &mut impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError>,
     v0: &[C64],
     k_krylov: usize,
     k_wanted: usize,
     which: Which,
-    _tol: f64,
+    tol: f64,
 ) -> Result<EigResult, QuSpinError> {
     if k_wanted == 0 {
         return Err(QuSpinError::ValueError(
@@ -136,6 +137,11 @@ pub fn lanczos_eig(
     if k_krylov < k_wanted {
         return Err(QuSpinError::ValueError(format!(
             "k_krylov ({k_krylov}) must be >= k_wanted ({k_wanted})"
+        )));
+    }
+    if !tol.is_finite() && tol != f64::INFINITY {
+        return Err(QuSpinError::ValueError(format!(
+            "tol must be finite or INFINITY; got {tol}"
         )));
     }
 
@@ -198,6 +204,14 @@ pub fn lanczos_eig(
             .map(|(hx, x)| (hx - C64::new(lam, 0.0) * x).norm_sqr())
             .sum::<f64>()
             .sqrt();
+
+        // Filter by tolerance
+        if residual > tol {
+            // Remove the eigenvector we just appended
+            eigenvectors.truncate(eigenvectors.len() - dim);
+            eigenvalues.pop();
+            continue;
+        }
         residuals.push(residual);
     }
 

--- a/crates/quspin-core/src/krylov/ftlm.rs
+++ b/crates/quspin-core/src/krylov/ftlm.rs
@@ -1,0 +1,128 @@
+use super::eig::TridiagEigen;
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+/// Partition function contribution from a single FTLM sample.
+///
+/// Computes `Z_r = Σ_n |c_{0,n}|² e^{-β E_n}` where `c_{0,n}` is the
+/// first component (overlap with starting vector) of the n-th eigenvector
+/// of the tridiagonal matrix.
+pub fn ftlm_partition(eig: &TridiagEigen, beta: f64) -> f64 {
+    (0..eig.k)
+        .map(|n| {
+            let c0n = eig.vec_element(0, n);
+            c0n * c0n * (-beta * eig.eigenvalues[n]).exp()
+        })
+        .sum()
+}
+
+/// Observable contribution from a single FTLM sample.
+///
+/// Computes `⟨O⟩_r · Z_r = Σ_n c_{0,n}* · e^{-β E_n} · (Σ_j c_{j,n} · o_j)`
+/// where `o_j = ⟨q_j|O|r⟩` are the observable matrix elements between
+/// each Krylov basis vector and the starting vector.
+///
+/// # Arguments
+/// - `eig` — eigendecomposition of the tridiagonal matrix
+/// - `obs_elements` — `⟨q_j|O|r⟩` for j = 0..k (length must equal `eig.k`)
+/// - `beta` — inverse temperature
+pub fn ftlm_observable(eig: &TridiagEigen, obs_elements: &[C64], beta: f64) -> C64 {
+    debug_assert_eq!(obs_elements.len(), eig.k);
+
+    (0..eig.k)
+        .map(|n| {
+            let c0n = C64::new(eig.vec_element(0, n), 0.0);
+            let weight = (-beta * eig.eigenvalues[n]).exp();
+
+            // Σ_j c_{j,n} · o_j
+            let proj: C64 = (0..eig.k)
+                .map(|j| C64::new(eig.vec_element(j, n), 0.0) * obs_elements[j])
+                .sum();
+
+            c0n.conj() * C64::new(weight, 0.0) * proj
+        })
+        .sum()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::super::eig::solve_tridiagonal;
+    use super::*;
+
+    #[test]
+    fn partition_beta_zero_is_one() {
+        // At β=0, all Boltzmann weights are 1.
+        // Z_r = Σ_n |c_{0,n}|² = 1 (eigenvectors are orthonormal,
+        // first row of orthogonal matrix has unit norm).
+        let eig = solve_tridiagonal(&[1.0, -1.0, 0.5], &[0.5, 0.3]);
+        let z = ftlm_partition(&eig, 0.0);
+        assert!((z - 1.0).abs() < 1e-12, "Z(β=0) = {z}, expected 1.0",);
+    }
+
+    #[test]
+    fn partition_positive_beta_less_than_one() {
+        // At β>0, the ground state dominates but Z_r < 1 unless
+        // the starting vector is exactly the ground state.
+        // Actually Z_r = Σ |c_{0n}|² e^{-βEn} which can be > 1 if E < 0.
+        // For positive eigenvalues, Z_r < 1.
+        let eig = solve_tridiagonal(&[2.0, 3.0], &[0.5]);
+        let z = ftlm_partition(&eig, 1.0);
+        // All eigenvalues positive → all weights < 1 → Z < 1
+        assert!(z < 1.0, "Z = {z}");
+        assert!(z > 0.0, "Z = {z}");
+    }
+
+    #[test]
+    fn partition_large_beta_approaches_ground_state() {
+        // At large β, the ground state contribution dominates.
+        let eig = solve_tridiagonal(&[0.0, 0.0], &[1.0]);
+        // Eigenvalues: ±1. Ground state: -1.
+        let z_large = ftlm_partition(&eig, 100.0);
+        let z_small = ftlm_partition(&eig, 0.01);
+
+        // At large β, Z_r ≈ |c_{0,gs}|² e^{-β·(-1)} ≈ 0.5 * e^{100}
+        // The ratio should show exponential growth with ground state
+        assert!(z_large > z_small);
+    }
+
+    #[test]
+    fn observable_identity_equals_partition() {
+        // If O = I, then o_j = ⟨q_j|I|r⟩ = ⟨q_j|r⟩ = δ_{j,0}
+        // (since r = q_0). So ⟨I⟩·Z = Z, meaning ftlm_observable = Z.
+        let eig = solve_tridiagonal(&[1.0, -1.0, 0.5], &[0.5, 0.3]);
+        let k = eig.k;
+        let mut obs = vec![C64::default(); k];
+        obs[0] = C64::new(1.0, 0.0); // ⟨q_0|I|r⟩ = 1
+
+        let beta = 0.5;
+        let z = ftlm_partition(&eig, beta);
+        let oz = ftlm_observable(&eig, &obs, beta);
+
+        assert!((oz.re - z).abs() < 1e-12, "⟨I⟩·Z = {oz}, Z = {z}",);
+        assert!(oz.im.abs() < 1e-12, "imaginary part = {}", oz.im);
+    }
+
+    #[test]
+    fn observable_at_beta_zero() {
+        // At β=0, ⟨O⟩ = Tr(O)/dim. For a single sample:
+        // oz_r = Σ_n c_{0,n}* · 1 · (Σ_j c_{j,n} o_j)
+        //      = Σ_j o_j · (Σ_n c_{0,n}* c_{j,n})
+        //      = Σ_j o_j · δ_{0,j}  (orthogonality of eigenvectors)
+        //      = o_0
+        let eig = solve_tridiagonal(&[0.0, 0.0], &[1.0]);
+        let obs = vec![C64::new(3.0, 1.0), C64::new(7.0, -2.0)];
+
+        let oz = ftlm_observable(&eig, &obs, 0.0);
+        // Should equal obs[0] = 3 + i
+        assert!(
+            (oz - obs[0]).norm() < 1e-12,
+            "⟨O⟩·Z at β=0: {oz}, expected {}",
+            obs[0],
+        );
+    }
+}

--- a/crates/quspin-core/src/krylov/ftlm_dynamic.rs
+++ b/crates/quspin-core/src/krylov/ftlm_dynamic.rs
@@ -1,0 +1,216 @@
+use super::eig::TridiagEigen;
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+/// Evaluate the continued fraction representation of the resolvent.
+///
+/// Computes `G(z) = 1 / (z - α₀ - β₀² / (z - α₁ - β₁² / ...))`
+///
+/// This represents `⟨v̂|(z − H)⁻¹|v̂⟩` where `α`, `β` are the Lanczos
+/// tridiagonal coefficients from starting vector `v̂ = v / ‖v‖`.
+/// Multiply by `‖v‖²` to get `⟨v|(z − H)⁻¹|v⟩`.
+///
+/// Evaluates from the bottom of the fraction upward for numerical stability.
+pub fn continued_fraction(alpha: &[f64], beta: &[f64], z: C64) -> C64 {
+    let k = alpha.len();
+    debug_assert!(k > 0);
+    debug_assert_eq!(beta.len() + 1, k);
+
+    // Start from the deepest level
+    let mut g = z - C64::new(alpha[k - 1], 0.0);
+    for j in (0..k - 1).rev() {
+        g = z - C64::new(alpha[j], 0.0) - C64::new(beta[j] * beta[j], 0.0) / g;
+    }
+    C64::new(1.0, 0.0) / g
+}
+
+/// Compute the spectral function contribution from one FTLM dynamic sample.
+///
+/// For a random vector `|r⟩`:
+/// - **Left Lanczos** on `|r⟩` provides Boltzmann-weighted Ritz values
+/// - **Right Lanczos** on `A|r⟩` provides the continued-fraction resolvent
+///
+/// The spectral function contribution at frequency `ω` is:
+/// ```text
+/// S_r(ω) = -(‖Ar‖² / π) Σ_n |c_{0n}^L|² e^{-β E_n^L}
+///           × Im[G_R(ω + E_n^L + iη)]
+/// ```
+///
+/// # Arguments
+/// - `left_eig` — eigendecomposition of the left tridiagonal (from `|r⟩`)
+/// - `right_alpha`, `right_beta` — tridiagonal from the right Lanczos (from `A|r⟩`)
+/// - `right_norm_sq` — `‖A|r⟩‖²`
+/// - `beta_temp` — inverse temperature `β`
+/// - `omegas` — frequency grid
+/// - `eta` — Lorentzian broadening parameter
+pub fn ftlm_dynamic_spectral(
+    left_eig: &TridiagEigen,
+    right_alpha: &[f64],
+    right_beta: &[f64],
+    right_norm_sq: f64,
+    beta_temp: f64,
+    omegas: &[f64],
+    eta: f64,
+) -> Vec<f64> {
+    let inv_pi = -1.0 / std::f64::consts::PI;
+
+    omegas
+        .iter()
+        .map(|&omega| {
+            let mut s = 0.0;
+            for n in 0..left_eig.k {
+                let c0n = left_eig.vec_element(0, n);
+                let weight = c0n * c0n * (-beta_temp * left_eig.eigenvalues[n]).exp();
+                let z = C64::new(omega + left_eig.eigenvalues[n], eta);
+                let g = continued_fraction(right_alpha, right_beta, z);
+                s += weight * inv_pi * (right_norm_sq * g).im;
+            }
+            s
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::super::eig::solve_tridiagonal;
+    use super::*;
+
+    #[test]
+    fn continued_fraction_1x1() {
+        // T = [[α₀]], G(z) = 1/(z - α₀)
+        let g = continued_fraction(&[2.0], &[], C64::new(5.0, 0.1));
+        let expected = C64::new(1.0, 0.0) / C64::new(3.0, 0.1);
+        assert!((g - expected).norm() < 1e-14);
+    }
+
+    #[test]
+    fn continued_fraction_2x2_matches_inverse() {
+        // T = [[α₀, β₀], [β₀, α₁]]
+        // G(z) = ⟨e₁|(z-T)⁻¹|e₁⟩ = (z - α₁) / ((z-α₀)(z-α₁) - β₀²)
+        let a0 = 1.0;
+        let a1 = -0.5;
+        let b0 = 0.7;
+        let z = C64::new(3.0, 0.2);
+
+        let g = continued_fraction(&[a0, a1], &[b0], z);
+        let expected = (z - C64::new(a1, 0.0))
+            / ((z - C64::new(a0, 0.0)) * (z - C64::new(a1, 0.0)) - C64::new(b0 * b0, 0.0));
+
+        assert!(
+            (g - expected).norm() < 1e-13,
+            "cf = {g}, expected = {expected}",
+        );
+    }
+
+    #[test]
+    fn continued_fraction_poles_at_eigenvalues() {
+        // Near an eigenvalue, Im[G] should have a peak.
+        // T = [[0, 1], [1, 0]], eigenvalues ±1.
+        let alpha = [0.0, 0.0];
+        let beta = [1.0];
+        let eta = 0.01;
+
+        // At ω=1 (eigenvalue), large |Im(G)|
+        let g_on = continued_fraction(&alpha, &beta, C64::new(1.0, eta));
+        // At ω=0.5 (off eigenvalue), smaller |Im(G)|
+        let g_off = continued_fraction(&alpha, &beta, C64::new(0.5, eta));
+
+        assert!(
+            g_on.im.abs() > g_off.im.abs(),
+            "on-resonance |Im(G)| = {} should exceed off-resonance {}",
+            g_on.im.abs(),
+            g_off.im.abs(),
+        );
+    }
+
+    #[test]
+    fn continued_fraction_sum_rule() {
+        // ∫ dω (-1/π) Im G(ω + iη) = 1 for normalized starting vector.
+        // Approximate with trapezoidal rule on a wide grid.
+        let alpha = [0.5, -0.3, 1.0];
+        let beta = [0.8, 0.4];
+        let eta = 0.1;
+
+        let n_pts = 10000;
+        let omega_min = -10.0;
+        let omega_max = 10.0;
+        let dw = (omega_max - omega_min) / n_pts as f64;
+
+        let integral: f64 = (0..=n_pts)
+            .map(|i| {
+                let omega = omega_min + i as f64 * dw;
+                let g = continued_fraction(&alpha, &beta, C64::new(omega, eta));
+                (-1.0 / std::f64::consts::PI) * g.im * dw
+            })
+            .sum();
+
+        assert!(
+            (integral - 1.0).abs() < 0.01,
+            "sum rule integral = {integral}, expected 1.0",
+        );
+    }
+
+    #[test]
+    fn dynamic_spectral_is_nonnegative() {
+        // S(ω) should be non-negative for all ω.
+        let left_eig = solve_tridiagonal(&[0.0, 0.0], &[1.0]);
+        let right_alpha = [0.5, -0.5];
+        let right_beta = [0.3];
+        let right_norm_sq = 0.5;
+
+        let omegas: Vec<f64> = (-50..=50).map(|i| i as f64 * 0.1).collect();
+        let s = ftlm_dynamic_spectral(
+            &left_eig,
+            &right_alpha,
+            &right_beta,
+            right_norm_sq,
+            1.0,
+            &omegas,
+            0.1,
+        );
+
+        for (i, &si) in s.iter().enumerate() {
+            assert!(si >= -1e-14, "S(ω={}) = {si} is negative", omegas[i],);
+        }
+    }
+
+    #[test]
+    fn dynamic_spectral_beta_zero_symmetric() {
+        // At β=0, all Boltzmann weights are equal, so S(ω) should have
+        // a specific symmetry structure.
+        let left_eig = solve_tridiagonal(&[0.0, 0.0], &[1.0]);
+        let right_alpha = [0.0, 0.0];
+        let right_beta = [1.0];
+        let right_norm_sq = 1.0;
+
+        let s_pos = ftlm_dynamic_spectral(
+            &left_eig,
+            &right_alpha,
+            &right_beta,
+            right_norm_sq,
+            0.0,
+            &[2.0],
+            0.1,
+        )[0];
+        let s_neg = ftlm_dynamic_spectral(
+            &left_eig,
+            &right_alpha,
+            &right_beta,
+            right_norm_sq,
+            0.0,
+            &[-2.0],
+            0.1,
+        )[0];
+
+        // At β=0, S(ω) = S(-ω) (detailed balance with equal weights)
+        assert!(
+            (s_pos - s_neg).abs() < 1e-12,
+            "S(2) = {s_pos}, S(-2) = {s_neg}",
+        );
+    }
+}

--- a/crates/quspin-core/src/krylov/ltlm.rs
+++ b/crates/quspin-core/src/krylov/ltlm.rs
@@ -1,0 +1,84 @@
+use super::eig::TridiagEigen;
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+/// Compute Krylov-space coefficients for `e^{-βH/2}|r⟩`.
+///
+/// Returns coefficients `g_j = Σ_n c_{0,n} · e^{-β E_n / 2} · c_{j,n}`
+/// such that `e^{-βH/2}|r⟩ = Σ_j g_j |q_j⟩`.
+///
+/// Usage: pass the result to `LanczosBasis::lin_comb` (or
+/// `LanczosBasisIter::lin_comb`) to get the full-space vector `|φ⟩`,
+/// then compute `⟨φ|O|φ⟩` for the LTLM observable estimate.
+pub fn ltlm_coeffs(eig: &TridiagEigen, beta: f64) -> Vec<C64> {
+    let k = eig.k;
+    let mut coeffs = vec![C64::default(); k];
+
+    for n in 0..k {
+        let c0n = eig.vec_element(0, n);
+        let weight = (-beta * eig.eigenvalues[n] / 2.0).exp();
+        let factor = c0n * weight;
+
+        for (j, cj) in coeffs.iter_mut().enumerate() {
+            *cj += C64::new(factor * eig.vec_element(j, n), 0.0);
+        }
+    }
+
+    coeffs
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::super::eig::solve_tridiagonal;
+    use super::*;
+
+    #[test]
+    fn coeffs_beta_zero_is_delta() {
+        // At β=0, e^{0} = I, so g_j = Σ_n c_{0,n} c_{j,n} = δ_{0,j}
+        let eig = solve_tridiagonal(&[1.0, -1.0, 0.5], &[0.5, 0.3]);
+        let coeffs = ltlm_coeffs(&eig, 0.0);
+
+        assert!(
+            (coeffs[0].re - 1.0).abs() < 1e-12,
+            "g[0] = {}, expected 1",
+            coeffs[0],
+        );
+        for (j, c) in coeffs.iter().enumerate().skip(1) {
+            assert!(c.norm() < 1e-12, "g[{j}] = {c}, expected 0",);
+        }
+    }
+
+    #[test]
+    fn coeffs_norm_squared_equals_partition() {
+        // ||e^{-βH/2}|r⟩||² = ⟨r|e^{-βH}|r⟩ = Z_r (the FTLM partition).
+        // Since |φ⟩ = Σ_j g_j |q_j⟩ and {q_j} are orthonormal,
+        // ||φ||² = Σ_j |g_j|².
+        use super::super::ftlm::ftlm_partition;
+
+        let eig = solve_tridiagonal(&[1.0, -1.0, 0.5], &[0.5, 0.3]);
+        let beta = 1.5;
+
+        let coeffs = ltlm_coeffs(&eig, beta);
+        let norm_sq: f64 = coeffs.iter().map(|c| c.norm_sqr()).sum();
+        let z = ftlm_partition(&eig, beta);
+
+        assert!((norm_sq - z).abs() < 1e-12, "||φ||² = {norm_sq}, Z = {z}",);
+    }
+
+    #[test]
+    fn coeffs_are_real_for_real_system() {
+        // For a real Hermitian system with real starting vector,
+        // all coefficients should be real.
+        let eig = solve_tridiagonal(&[2.0, -0.5], &[1.0]);
+        let coeffs = ltlm_coeffs(&eig, 0.7);
+
+        for (j, c) in coeffs.iter().enumerate() {
+            assert!(c.im.abs() < 1e-14, "g[{j}].im = {}, expected 0", c.im,);
+        }
+    }
+}

--- a/crates/quspin-core/src/krylov/mod.rs
+++ b/crates/quspin-core/src/krylov/mod.rs
@@ -1,0 +1,5 @@
+pub mod basis;
+pub mod eig;
+pub mod ftlm;
+pub mod ftlm_dynamic;
+pub mod ltlm;

--- a/crates/quspin-core/src/lib.rs
+++ b/crates/quspin-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod dtype;
 pub mod error;
 pub mod expm;
 pub mod hamiltonian;
+pub mod krylov;
 pub mod operator;
 pub mod primitive;
 pub mod qmatrix;

--- a/crates/quspin-py/src/krylov.rs
+++ b/crates/quspin-py/src/krylov.rs
@@ -190,11 +190,16 @@ impl PyFTLM {
     ///     observable: ``Hamiltonian`` representing the observable operator.
     ///     beta:       Inverse temperature.
     ///     time:       Evaluation time for time-dependent coefficients (default 0.0).
+    ///     stored:     If ``True`` (default), store all Lanczos vectors for
+    ///                 O(k × dim) memory but only one Lanczos build. If
+    ///                 ``False``, use O(k + dim) memory by replaying the
+    ///                 recurrence at the cost of extra matvecs.
     ///
     /// Returns:
     ///     ``(z_r, oz_r)`` where ``z_r`` is the partition function contribution
     ///     and ``oz_r`` is the ``⟨O⟩ · Z`` contribution (complex).
-    #[pyo3(signature = (v0, k, observable, beta, time = 0.0))]
+    #[pyo3(signature = (v0, k, observable, beta, time = 0.0, stored = true))]
+    #[allow(clippy::too_many_arguments)]
     fn sample(
         &self,
         py: Python<'_>,
@@ -203,6 +208,7 @@ impl PyFTLM {
         observable: &PyHamiltonian,
         beta: f64,
         time: f64,
+        stored: bool,
     ) -> PyResult<(f64, Complex64)> {
         let n = self.inner.dim();
         let v0_vec = extract_c64_vec(v0);
@@ -216,33 +222,52 @@ impl PyFTLM {
         let o_inner = Arc::clone(&observable.inner);
 
         let result = py.allow_threads(move || -> Result<(f64, C64), QuSpinError> {
-            // Build Lanczos basis
-            let basis = LanczosBasis::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+            if stored {
+                // Stored path: keep all basis vectors, single Lanczos build
+                let basis = LanczosBasis::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+                let eig = eig::solve_tridiagonal(basis.alpha(), basis.beta());
 
-            // Solve tridiagonal eigenproblem
-            let eig = eig::solve_tridiagonal(basis.alpha(), basis.beta());
+                let q0 = basis.q(0);
+                let mut o_q0 = vec![C64::default(); n];
+                o_inner.dot(true, time, q0, &mut o_q0)?;
 
-            // Compute observable matrix elements: o_j = ⟨q_j|O|r⟩
-            // where r = q_0 (first basis vector, which is v0 normalized)
-            let q0 = basis.q(0);
-            let mut o_q0 = vec![C64::default(); n];
-            o_inner.dot(true, time, q0, &mut o_q0)?;
+                let obs_elements: Vec<C64> = (0..basis.k())
+                    .map(|j| {
+                        basis
+                            .q(j)
+                            .iter()
+                            .zip(o_q0.iter())
+                            .map(|(a, b)| a.conj() * b)
+                            .sum()
+                    })
+                    .collect();
 
-            let obs_elements: Vec<C64> = (0..basis.k())
-                .map(|j| {
-                    basis
-                        .q(j)
-                        .iter()
-                        .zip(o_q0.iter())
-                        .map(|(a, b)| a.conj() * b)
-                        .sum()
-                })
-                .collect();
+                let z_r = ftlm::ftlm_partition(&eig, beta);
+                let oz_r = ftlm::ftlm_observable(&eig, &obs_elements, beta);
+                Ok((z_r, oz_r))
+            } else {
+                // Replay path: O(k + dim) memory, extra matvecs
+                let iter_basis =
+                    LanczosBasisIter::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+                let eig = eig::solve_tridiagonal(iter_basis.alpha(), iter_basis.beta());
 
-            let z_r = ftlm::ftlm_partition(&eig, beta);
-            let oz_r = ftlm::ftlm_observable(&eig, &obs_elements, beta);
+                // Compute O|q_0⟩ once (q_0 is the normalized v0)
+                let norm0 = v0_vec.iter().map(|c| c.norm_sqr()).sum::<f64>().sqrt();
+                let q0: Vec<C64> = v0_vec.iter().map(|&c| c / norm0).collect();
+                let mut o_q0 = vec![C64::default(); n];
+                o_inner.dot(true, time, &q0, &mut o_q0)?;
 
-            Ok((z_r, oz_r))
+                // Replay recurrence to compute obs_elements on the fly
+                let mut obs_elements = Vec::with_capacity(iter_basis.k());
+                iter_basis.for_each(&mut make_matvec(&h_inner, time), |_j, q_j| {
+                    let elem: C64 = q_j.iter().zip(o_q0.iter()).map(|(a, b)| a.conj() * b).sum();
+                    obs_elements.push(elem);
+                })?;
+
+                let z_r = ftlm::ftlm_partition(&eig, beta);
+                let oz_r = ftlm::ftlm_observable(&eig, &obs_elements, beta);
+                Ok((z_r, oz_r))
+            }
         });
 
         let (z_r, oz_r) = result.map_err(Error::from)?;
@@ -292,11 +317,16 @@ impl PyLTLM {
     ///     observable: ``Hamiltonian`` representing the observable operator.
     ///     beta:       Inverse temperature.
     ///     time:       Evaluation time for time-dependent coefficients (default 0.0).
+    ///     stored:     If ``True`` (default), store all Lanczos vectors for
+    ///                 O(k × dim) memory but only one Lanczos build. If
+    ///                 ``False``, use O(k + dim) memory by replaying the
+    ///                 recurrence at the cost of extra matvecs.
     ///
     /// Returns:
     ///     ``(z_r, oz_r)`` where ``z_r`` is the partition function contribution
     ///     and ``oz_r`` is ``⟨φ|O|φ⟩`` (complex).
-    #[pyo3(signature = (v0, k, observable, beta, time = 0.0))]
+    #[pyo3(signature = (v0, k, observable, beta, time = 0.0, stored = true))]
+    #[allow(clippy::too_many_arguments)]
     fn sample(
         &self,
         py: Python<'_>,
@@ -305,6 +335,7 @@ impl PyLTLM {
         observable: &PyHamiltonian,
         beta: f64,
         time: f64,
+        stored: bool,
     ) -> PyResult<(f64, Complex64)> {
         let n = self.inner.dim();
         let v0_vec = extract_c64_vec(v0);
@@ -318,32 +349,47 @@ impl PyLTLM {
         let o_inner = Arc::clone(&observable.inner);
 
         let result = py.allow_threads(move || -> Result<(f64, C64), QuSpinError> {
-            // Build stored Lanczos basis
-            let basis = LanczosBasis::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+            if stored {
+                // Stored path: keep all basis vectors
+                let basis = LanczosBasis::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+                let eig = eig::solve_tridiagonal(basis.alpha(), basis.beta());
+                let z_r = ftlm::ftlm_partition(&eig, beta);
 
-            // Solve tridiagonal eigenproblem
-            let eig = eig::solve_tridiagonal(basis.alpha(), basis.beta());
+                let coeffs = ltlm::ltlm_coeffs(&eig, beta);
+                let mut phi = vec![C64::default(); n];
+                basis.lin_comb(&coeffs, &mut phi)?;
 
-            // Partition function (same as FTLM)
-            let z_r = ftlm::ftlm_partition(&eig, beta);
+                let mut o_phi = vec![C64::default(); n];
+                o_inner.dot(true, time, &phi, &mut o_phi)?;
 
-            // Compute |φ⟩ = e^{-βH/2}|r⟩ via Krylov projection
-            let coeffs = ltlm::ltlm_coeffs(&eig, beta);
-            let mut phi = vec![C64::default(); n];
-            basis.lin_comb(&coeffs, &mut phi)?;
+                let oz_r: C64 = phi
+                    .iter()
+                    .zip(o_phi.iter())
+                    .map(|(a, b)| a.conj() * b)
+                    .sum();
+                Ok((z_r, oz_r))
+            } else {
+                // Replay path: O(k + dim) memory, extra matvecs
+                let iter_basis =
+                    LanczosBasisIter::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+                let eig = eig::solve_tridiagonal(iter_basis.alpha(), iter_basis.beta());
+                let z_r = ftlm::ftlm_partition(&eig, beta);
 
-            // Compute O|φ⟩
-            let mut o_phi = vec![C64::default(); n];
-            o_inner.dot(true, time, &phi, &mut o_phi)?;
+                // Compute |φ⟩ = e^{-βH/2}|r⟩ via replay
+                let coeffs = ltlm::ltlm_coeffs(&eig, beta);
+                let mut phi = vec![C64::default(); n];
+                iter_basis.lin_comb(&mut make_matvec(&h_inner, time), &coeffs, &mut phi)?;
 
-            // ⟨φ|O|φ⟩
-            let oz_r: C64 = phi
-                .iter()
-                .zip(o_phi.iter())
-                .map(|(a, b)| a.conj() * b)
-                .sum();
+                let mut o_phi = vec![C64::default(); n];
+                o_inner.dot(true, time, &phi, &mut o_phi)?;
 
-            Ok((z_r, oz_r))
+                let oz_r: C64 = phi
+                    .iter()
+                    .zip(o_phi.iter())
+                    .map(|(a, b)| a.conj() * b)
+                    .sum();
+                Ok((z_r, oz_r))
+            }
         });
 
         let (z_r, oz_r) = result.map_err(Error::from)?;

--- a/crates/quspin-py/src/krylov.rs
+++ b/crates/quspin-py/src/krylov.rs
@@ -1,0 +1,468 @@
+use crate::error::Error;
+use crate::hamiltonian::PyHamiltonian;
+use num_complex::Complex;
+use numpy::{Complex64, PyArray1, PyArray2, PyArrayMethods, ToPyArray};
+use pyo3::prelude::*;
+use quspin_core::error::QuSpinError;
+use quspin_core::hamiltonian::HamiltonianInner;
+use quspin_core::krylov::{
+    basis::{LanczosBasis, LanczosBasisIter},
+    eig::{self, Which},
+    ftlm, ftlm_dynamic, ltlm,
+};
+use std::sync::Arc;
+
+type C64 = Complex<f64>;
+
+/// Convert a Python "which" string to the Rust enum.
+fn parse_which(which: &str) -> PyResult<Which> {
+    match which {
+        "SA" | "sa" => Ok(Which::SmallestAlgebraic),
+        "LA" | "la" => Ok(Which::LargestAlgebraic),
+        "SM" | "sm" => Ok(Which::SmallestMagnitude),
+        _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown 'which' value: {which:?}; expected \"SA\", \"LA\", or \"SM\""
+        ))),
+    }
+}
+
+/// Extract a complex128 numpy array into a Vec<Complex<f64>>.
+fn extract_c64_vec(arr: &Bound<'_, PyArray1<Complex64>>) -> Vec<C64> {
+    unsafe {
+        arr.as_array()
+            .iter()
+            .map(|c| C64::new(c.re, c.im))
+            .collect()
+    }
+}
+
+/// Build a matvec closure from a HamiltonianInner at a fixed time.
+fn make_matvec(
+    inner: &Arc<HamiltonianInner>,
+    time: f64,
+) -> impl FnMut(&[C64], &mut [C64]) -> Result<(), QuSpinError> + '_ {
+    move |input: &[C64], output: &mut [C64]| inner.dot(true, time, input, output)
+}
+
+// ---------------------------------------------------------------------------
+// EigSolver
+// ---------------------------------------------------------------------------
+
+/// Lanczos eigenvalue solver.
+///
+/// Wraps a `Hamiltonian` and computes eigenvalues/eigenvectors using the
+/// Lanczos algorithm with full re-orthogonalization.
+#[pyclass(name = "EigSolver", module = "quspin._rs")]
+pub struct PyEigSolver {
+    inner: Arc<HamiltonianInner>,
+}
+
+#[pymethods]
+impl PyEigSolver {
+    #[new]
+    fn new(hamiltonian: &PyHamiltonian) -> Self {
+        PyEigSolver {
+            inner: Arc::clone(&hamiltonian.inner),
+        }
+    }
+
+    #[getter]
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    /// Compute eigenvalues and eigenvectors.
+    ///
+    /// Args:
+    ///     v0:       Initial vector, shape ``(dim,)``.
+    ///     k_krylov: Krylov subspace dimension.
+    ///     k_wanted: Number of eigenpairs to return (default 1).
+    ///     which:    ``"SA"`` (smallest algebraic), ``"LA"`` (largest),
+    ///               or ``"SM"`` (smallest magnitude). Default ``"SA"``.
+    ///     tol:      Convergence tolerance (default 1e-10).
+    ///     time:     Evaluation time for time-dependent coefficients (default 0.0).
+    ///
+    /// Returns:
+    ///     ``(eigenvalues, eigenvectors, residuals)`` where eigenvalues has
+    ///     shape ``(k_wanted,)``, eigenvectors has shape ``(k_wanted, dim)``,
+    ///     and residuals has shape ``(k_wanted,)``.
+    #[pyo3(signature = (v0, k_krylov, k_wanted = 1, which = "SA", tol = 1e-10, time = 0.0))]
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    fn solve<'py>(
+        &self,
+        py: Python<'py>,
+        v0: &Bound<'py, PyArray1<Complex64>>,
+        k_krylov: usize,
+        k_wanted: usize,
+        which: &str,
+        tol: f64,
+        time: f64,
+    ) -> PyResult<(
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray2<Complex64>>,
+        Bound<'py, PyArray1<f64>>,
+    )> {
+        let n = self.inner.dim();
+        let v0_vec = extract_c64_vec(v0);
+        if v0_vec.len() != n {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "v0 must have length {n}"
+            )));
+        }
+        let which_enum = parse_which(which)?;
+
+        let inner = Arc::clone(&self.inner);
+        let result = py.allow_threads(move || {
+            eig::lanczos_eig(
+                &mut make_matvec(&inner, time),
+                &v0_vec,
+                k_krylov,
+                k_wanted,
+                which_enum,
+                tol,
+            )
+        });
+        let result = result.map_err(Error::from)?;
+
+        let eigenvalues = result.eigenvalues.to_pyarray(py);
+        let residuals = result.residuals.to_pyarray(py);
+
+        let n_eig = result.n_eig();
+        let dim = result.dim();
+        let rows: Vec<Vec<Complex64>> = (0..n_eig)
+            .map(|i| {
+                result
+                    .eigenvector(i)
+                    .iter()
+                    .map(|c| Complex64::new(c.re, c.im))
+                    .collect()
+            })
+            .collect();
+        let eigenvectors = PyArray2::from_vec2(py, &rows).map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to create ({n_eig}, {dim}) array"
+            ))
+        })?;
+
+        Ok((eigenvalues, eigenvectors, residuals))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("EigSolver(dim={})", self.inner.dim())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FTLM
+// ---------------------------------------------------------------------------
+
+/// Finite Temperature Lanczos Method.
+///
+/// Computes thermal expectation values using quantum typicality.
+#[pyclass(name = "FTLM", module = "quspin._rs")]
+pub struct PyFTLM {
+    inner: Arc<HamiltonianInner>,
+}
+
+#[pymethods]
+impl PyFTLM {
+    #[new]
+    fn new(hamiltonian: &PyHamiltonian) -> Self {
+        PyFTLM {
+            inner: Arc::clone(&hamiltonian.inner),
+        }
+    }
+
+    #[getter]
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    /// Compute a single FTLM sample.
+    ///
+    /// Builds a Lanczos basis from ``v0`` using the Hamiltonian, then
+    /// computes the partition function contribution and the observable
+    /// expectation value contribution for the given inverse temperature.
+    ///
+    /// Args:
+    ///     v0:         Random starting vector, shape ``(dim,)``.
+    ///     k:          Number of Lanczos steps.
+    ///     observable: ``Hamiltonian`` representing the observable operator.
+    ///     beta:       Inverse temperature.
+    ///     time:       Evaluation time for time-dependent coefficients (default 0.0).
+    ///
+    /// Returns:
+    ///     ``(z_r, oz_r)`` where ``z_r`` is the partition function contribution
+    ///     and ``oz_r`` is the ``⟨O⟩ · Z`` contribution (complex).
+    #[pyo3(signature = (v0, k, observable, beta, time = 0.0))]
+    fn sample(
+        &self,
+        py: Python<'_>,
+        v0: &Bound<'_, PyArray1<Complex64>>,
+        k: usize,
+        observable: &PyHamiltonian,
+        beta: f64,
+        time: f64,
+    ) -> PyResult<(f64, Complex64)> {
+        let n = self.inner.dim();
+        let v0_vec = extract_c64_vec(v0);
+        if v0_vec.len() != n {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "v0 must have length {n}"
+            )));
+        }
+
+        let h_inner = Arc::clone(&self.inner);
+        let o_inner = Arc::clone(&observable.inner);
+
+        let result = py.allow_threads(move || -> Result<(f64, C64), QuSpinError> {
+            // Build Lanczos basis
+            let basis = LanczosBasis::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+
+            // Solve tridiagonal eigenproblem
+            let eig = eig::solve_tridiagonal(basis.alpha(), basis.beta());
+
+            // Compute observable matrix elements: o_j = ⟨q_j|O|r⟩
+            // where r = q_0 (first basis vector, which is v0 normalized)
+            let q0 = basis.q(0);
+            let mut o_q0 = vec![C64::default(); n];
+            o_inner.dot(true, time, q0, &mut o_q0)?;
+
+            let obs_elements: Vec<C64> = (0..basis.k())
+                .map(|j| {
+                    basis
+                        .q(j)
+                        .iter()
+                        .zip(o_q0.iter())
+                        .map(|(a, b)| a.conj() * b)
+                        .sum()
+                })
+                .collect();
+
+            let z_r = ftlm::ftlm_partition(&eig, beta);
+            let oz_r = ftlm::ftlm_observable(&eig, &obs_elements, beta);
+
+            Ok((z_r, oz_r))
+        });
+
+        let (z_r, oz_r) = result.map_err(Error::from)?;
+        Ok((z_r, Complex64::new(oz_r.re, oz_r.im)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("FTLM(dim={})", self.inner.dim())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LTLM
+// ---------------------------------------------------------------------------
+
+/// Low Temperature Lanczos Method.
+///
+/// Uses ``e^{-βH/2}`` on both sides for lower estimator variance at low
+/// temperature.
+#[pyclass(name = "LTLM", module = "quspin._rs")]
+pub struct PyLTLM {
+    inner: Arc<HamiltonianInner>,
+}
+
+#[pymethods]
+impl PyLTLM {
+    #[new]
+    fn new(hamiltonian: &PyHamiltonian) -> Self {
+        PyLTLM {
+            inner: Arc::clone(&hamiltonian.inner),
+        }
+    }
+
+    #[getter]
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    /// Compute a single LTLM sample.
+    ///
+    /// Builds a Lanczos basis from ``v0``, computes ``|φ⟩ = e^{-βH/2}|r⟩``
+    /// via the Krylov projection, then evaluates ``⟨φ|O|φ⟩``.
+    ///
+    /// Args:
+    ///     v0:         Random starting vector, shape ``(dim,)``.
+    ///     k:          Number of Lanczos steps.
+    ///     observable: ``Hamiltonian`` representing the observable operator.
+    ///     beta:       Inverse temperature.
+    ///     time:       Evaluation time for time-dependent coefficients (default 0.0).
+    ///
+    /// Returns:
+    ///     ``(z_r, oz_r)`` where ``z_r`` is the partition function contribution
+    ///     and ``oz_r`` is ``⟨φ|O|φ⟩`` (complex).
+    #[pyo3(signature = (v0, k, observable, beta, time = 0.0))]
+    fn sample(
+        &self,
+        py: Python<'_>,
+        v0: &Bound<'_, PyArray1<Complex64>>,
+        k: usize,
+        observable: &PyHamiltonian,
+        beta: f64,
+        time: f64,
+    ) -> PyResult<(f64, Complex64)> {
+        let n = self.inner.dim();
+        let v0_vec = extract_c64_vec(v0);
+        if v0_vec.len() != n {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "v0 must have length {n}"
+            )));
+        }
+
+        let h_inner = Arc::clone(&self.inner);
+        let o_inner = Arc::clone(&observable.inner);
+
+        let result = py.allow_threads(move || -> Result<(f64, C64), QuSpinError> {
+            // Build stored Lanczos basis
+            let basis = LanczosBasis::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+
+            // Solve tridiagonal eigenproblem
+            let eig = eig::solve_tridiagonal(basis.alpha(), basis.beta());
+
+            // Partition function (same as FTLM)
+            let z_r = ftlm::ftlm_partition(&eig, beta);
+
+            // Compute |φ⟩ = e^{-βH/2}|r⟩ via Krylov projection
+            let coeffs = ltlm::ltlm_coeffs(&eig, beta);
+            let mut phi = vec![C64::default(); n];
+            basis.lin_comb(&coeffs, &mut phi)?;
+
+            // Compute O|φ⟩
+            let mut o_phi = vec![C64::default(); n];
+            o_inner.dot(true, time, &phi, &mut o_phi)?;
+
+            // ⟨φ|O|φ⟩
+            let oz_r: C64 = phi
+                .iter()
+                .zip(o_phi.iter())
+                .map(|(a, b)| a.conj() * b)
+                .sum();
+
+            Ok((z_r, oz_r))
+        });
+
+        let (z_r, oz_r) = result.map_err(Error::from)?;
+        Ok((z_r, Complex64::new(oz_r.re, oz_r.im)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("LTLM(dim={})", self.inner.dim())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FTLMDynamic
+// ---------------------------------------------------------------------------
+
+/// FTLM dynamic correlations (spectral function).
+///
+/// Computes the spectral function ``S(ω)`` via two independent Lanczos runs.
+#[pyclass(name = "FTLMDynamic", module = "quspin._rs")]
+pub struct PyFTLMDynamic {
+    inner: Arc<HamiltonianInner>,
+}
+
+#[pymethods]
+impl PyFTLMDynamic {
+    #[new]
+    fn new(hamiltonian: &PyHamiltonian) -> Self {
+        PyFTLMDynamic {
+            inner: Arc::clone(&hamiltonian.inner),
+        }
+    }
+
+    #[getter]
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    /// Compute one FTLM dynamic sample for the spectral function.
+    ///
+    /// Performs two Lanczos runs: one from ``v0`` (left, for Boltzmann
+    /// weights) and one from ``A|v0⟩`` (right, for the continued-fraction
+    /// resolvent).
+    ///
+    /// Args:
+    ///     v0:       Random starting vector, shape ``(dim,)``.
+    ///     k:        Number of Lanczos steps for each run.
+    ///     operator: ``Hamiltonian`` representing the operator ``A``.
+    ///     beta:     Inverse temperature.
+    ///     omegas:   Frequency grid, shape ``(n_omega,)``.
+    ///     eta:      Lorentzian broadening parameter.
+    ///     time:     Evaluation time for time-dependent coefficients (default 0.0).
+    ///
+    /// Returns:
+    ///     Spectral function contribution ``S_r(ω)`` as a 1-D array of shape
+    ///     ``(n_omega,)``.
+    #[pyo3(signature = (v0, k, operator, beta, omegas, eta, time = 0.0))]
+    #[allow(clippy::too_many_arguments)]
+    fn sample<'py>(
+        &self,
+        py: Python<'py>,
+        v0: &Bound<'py, PyArray1<Complex64>>,
+        k: usize,
+        operator: &PyHamiltonian,
+        beta: f64,
+        omegas: &Bound<'py, PyArray1<f64>>,
+        eta: f64,
+        time: f64,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = self.inner.dim();
+        let v0_vec = extract_c64_vec(v0);
+        if v0_vec.len() != n {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "v0 must have length {n}"
+            )));
+        }
+        let omegas_vec: Vec<f64> = unsafe { omegas.as_array().to_vec() };
+
+        let h_inner = Arc::clone(&self.inner);
+        let a_inner = Arc::clone(&operator.inner);
+
+        let result = py.allow_threads(move || -> Result<Vec<f64>, QuSpinError> {
+            // Left Lanczos: build basis from v0 using H
+            let left_basis = LanczosBasisIter::build(&mut make_matvec(&h_inner, time), &v0_vec, k)?;
+            let left_eig = eig::solve_tridiagonal(left_basis.alpha(), left_basis.beta());
+
+            // Compute A|v0⟩ (using normalized v0 from the left basis)
+            let norm0 = v0_vec.iter().map(|c| c.norm_sqr()).sum::<f64>().sqrt();
+            let v0_normed: Vec<C64> = v0_vec.iter().map(|&c| c / norm0).collect();
+            let mut a_v0 = vec![C64::default(); n];
+            a_inner.dot(true, time, &v0_normed, &mut a_v0)?;
+
+            let right_norm_sq: f64 = a_v0.iter().map(|c| c.norm_sqr()).sum();
+
+            if right_norm_sq < f64::EPSILON {
+                // A|v0⟩ = 0, no spectral weight
+                return Ok(vec![0.0; omegas_vec.len()]);
+            }
+
+            // Right Lanczos: build basis from A|v0⟩ using H
+            let right_basis = LanczosBasisIter::build(&mut make_matvec(&h_inner, time), &a_v0, k)?;
+
+            let spectral = ftlm_dynamic::ftlm_dynamic_spectral(
+                &left_eig,
+                right_basis.alpha(),
+                right_basis.beta(),
+                right_norm_sq,
+                beta,
+                &omegas_vec,
+                eta,
+            );
+
+            Ok(spectral)
+        });
+
+        let spectral = result.map_err(Error::from)?;
+        Ok(spectral.to_pyarray(py))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("FTLMDynamic(dim={})", self.inner.dim())
+    }
+}

--- a/crates/quspin-py/src/lib.rs
+++ b/crates/quspin-py/src/lib.rs
@@ -2,6 +2,7 @@ pub mod basis;
 pub mod dtype;
 pub mod error;
 pub mod hamiltonian;
+pub mod krylov;
 pub mod macros;
 pub mod operator;
 pub mod qmatrix;
@@ -9,6 +10,7 @@ pub mod schrodinger;
 
 use basis::{PyBosonBasis, PyFermionBasis, PyGenericBasis, PySpinBasis};
 use hamiltonian::{PyHamiltonian, PyStatic};
+use krylov::{PyEigSolver, PyFTLM, PyFTLMDynamic, PyLTLM};
 use operator::{
     PyBondOperator, PyBosonOperator, PyFermionOperator, PyMonomialOperator, PyPauliOperator,
 };
@@ -34,5 +36,10 @@ fn _rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyStatic>()?;
     m.add_class::<PyHamiltonian>()?;
     m.add_class::<PySchrodingerEq>()?;
+    // Krylov subspace methods
+    m.add_class::<PyEigSolver>()?;
+    m.add_class::<PyFTLM>()?;
+    m.add_class::<PyLTLM>()?;
+    m.add_class::<PyFTLMDynamic>()?;
     Ok(())
 }

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -686,6 +686,7 @@ class FTLM:
         observable: Hamiltonian,
         beta: float,
         time: float = 0.0,
+        stored: bool = True,
     ) -> tuple[float, complex]:
         """Compute a single FTLM sample.
 
@@ -695,6 +696,9 @@ class FTLM:
             observable: ``Hamiltonian`` representing the observable.
             beta:       Inverse temperature.
             time:       Evaluation time for time-dependent coefficients.
+            stored:     If ``True``, store all Lanczos vectors (O(k × dim) memory,
+                        one Lanczos build). If ``False``, replay the recurrence
+                        (O(k + dim) memory, extra matvecs).
 
         Returns:
             ``(z_r, oz_r)`` — partition function contribution and
@@ -721,6 +725,7 @@ class LTLM:
         observable: Hamiltonian,
         beta: float,
         time: float = 0.0,
+        stored: bool = True,
     ) -> tuple[float, complex]:
         """Compute a single LTLM sample.
 
@@ -730,6 +735,9 @@ class LTLM:
             observable: ``Hamiltonian`` representing the observable.
             beta:       Inverse temperature.
             time:       Evaluation time for time-dependent coefficients.
+            stored:     If ``True``, store all Lanczos vectors (O(k × dim) memory,
+                        one Lanczos build). If ``False``, replay the recurrence
+                        (O(k + dim) memory, extra matvecs).
 
         Returns:
             ``(z_r, oz_r)`` — partition function contribution and

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -623,3 +623,154 @@ class SchrodingerEq:
         ...
 
     def __repr__(self) -> str: ...
+
+# ---------------------------------------------------------------------------
+# Krylov subspace methods
+# ---------------------------------------------------------------------------
+
+class EigSolver:
+    """Lanczos eigenvalue solver with full re-orthogonalization.
+
+    Args:
+        hamiltonian: A ``Hamiltonian`` whose eigenvalues to compute.
+    """
+
+    def __init__(self, hamiltonian: Hamiltonian) -> None: ...
+    @property
+    def dim(self) -> int: ...
+    def solve(
+        self,
+        v0: npt.NDArray[Any],
+        k_krylov: int,
+        k_wanted: int = 1,
+        which: str = "SA",
+        tol: float = 1e-10,
+        time: float = 0.0,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[Any], npt.NDArray[np.float64]]:
+        """Compute eigenvalues and eigenvectors.
+
+        Args:
+            v0:       Initial vector, shape ``(dim,)``.
+            k_krylov: Krylov subspace dimension.
+            k_wanted: Number of eigenpairs to return.
+            which:    ``"SA"`` (smallest algebraic), ``"LA"`` (largest),
+                      or ``"SM"`` (smallest magnitude).
+            tol:      Convergence tolerance.
+            time:     Evaluation time for time-dependent coefficients.
+
+        Returns:
+            ``(eigenvalues, eigenvectors, residuals)`` where eigenvalues has
+            shape ``(k_wanted,)``, eigenvectors ``(k_wanted, dim)``, and
+            residuals ``(k_wanted,)``.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
+class FTLM:
+    """Finite Temperature Lanczos Method.
+
+    Args:
+        hamiltonian: A ``Hamiltonian`` for the system.
+    """
+
+    def __init__(self, hamiltonian: Hamiltonian) -> None: ...
+    @property
+    def dim(self) -> int: ...
+    def sample(
+        self,
+        v0: npt.NDArray[Any],
+        k: int,
+        observable: Hamiltonian,
+        beta: float,
+        time: float = 0.0,
+    ) -> tuple[float, complex]:
+        """Compute a single FTLM sample.
+
+        Args:
+            v0:         Random starting vector, shape ``(dim,)``.
+            k:          Number of Lanczos steps.
+            observable: ``Hamiltonian`` representing the observable.
+            beta:       Inverse temperature.
+            time:       Evaluation time for time-dependent coefficients.
+
+        Returns:
+            ``(z_r, oz_r)`` — partition function contribution and
+            ``⟨O⟩ · Z`` contribution.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
+class LTLM:
+    """Low Temperature Lanczos Method.
+
+    Args:
+        hamiltonian: A ``Hamiltonian`` for the system.
+    """
+
+    def __init__(self, hamiltonian: Hamiltonian) -> None: ...
+    @property
+    def dim(self) -> int: ...
+    def sample(
+        self,
+        v0: npt.NDArray[Any],
+        k: int,
+        observable: Hamiltonian,
+        beta: float,
+        time: float = 0.0,
+    ) -> tuple[float, complex]:
+        """Compute a single LTLM sample.
+
+        Args:
+            v0:         Random starting vector, shape ``(dim,)``.
+            k:          Number of Lanczos steps.
+            observable: ``Hamiltonian`` representing the observable.
+            beta:       Inverse temperature.
+            time:       Evaluation time for time-dependent coefficients.
+
+        Returns:
+            ``(z_r, oz_r)`` — partition function contribution and
+            ``⟨φ|O|φ⟩`` where ``|φ⟩ = e^{-βH/2}|r⟩``.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
+class FTLMDynamic:
+    """FTLM dynamic correlations (spectral function).
+
+    Args:
+        hamiltonian: A ``Hamiltonian`` for the system.
+    """
+
+    def __init__(self, hamiltonian: Hamiltonian) -> None: ...
+    @property
+    def dim(self) -> int: ...
+    def sample(
+        self,
+        v0: npt.NDArray[Any],
+        k: int,
+        operator: Hamiltonian,
+        beta: float,
+        omegas: npt.NDArray[np.float64],
+        eta: float,
+        time: float = 0.0,
+    ) -> npt.NDArray[np.float64]:
+        """Compute one FTLM dynamic sample for the spectral function.
+
+        Args:
+            v0:       Random starting vector, shape ``(dim,)``.
+            k:        Number of Lanczos steps for each run.
+            operator: ``Hamiltonian`` representing the operator ``A``.
+            beta:     Inverse temperature.
+            omegas:   Frequency grid, shape ``(n_omega,)``.
+            eta:      Lorentzian broadening parameter.
+            time:     Evaluation time for time-dependent coefficients.
+
+        Returns:
+            Spectral function contribution, shape ``(n_omega,)``.
+        """
+        ...
+
+    def __repr__(self) -> str: ...

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -652,16 +652,18 @@ class EigSolver:
         Args:
             v0:       Initial vector, shape ``(dim,)``.
             k_krylov: Krylov subspace dimension.
-            k_wanted: Number of eigenpairs to return.
+            k_wanted: Maximum number of eigenpairs to return.
             which:    ``"SA"`` (smallest algebraic), ``"LA"`` (largest),
                       or ``"SM"`` (smallest magnitude).
-            tol:      Convergence tolerance.
+            tol:      Convergence tolerance on residual norms. Only eigenpairs
+                      with residual ``≤ tol`` are returned. Pass ``float('inf')``
+                      to disable filtering.
             time:     Evaluation time for time-dependent coefficients.
 
         Returns:
-            ``(eigenvalues, eigenvectors, residuals)`` where eigenvalues has
-            shape ``(k_wanted,)``, eigenvectors ``(k_wanted, dim)``, and
-            residuals ``(k_wanted,)``.
+            ``(eigenvalues, eigenvectors, residuals)`` where ``n_eig`` is the
+            number of converged eigenpairs (may be less than ``k_wanted``).
+            Shapes: ``(n_eig,)``, ``(n_eig, dim)``, ``(n_eig,)``.
         """
         ...
 


### PR DESCRIPTION
## Summary

Implements the Krylov subspace methods specified in #9, with all design revisions agreed during review:

- **Lanczos with full QR re-orthogonalization** (two-pass MGS) — no `ndarray-linalg`/OpenBLAS dependency, uses `nalgebra::SymmetricEigen` for the K×K tridiagonal eigenproblem
- **`LanczosBasis`** (stored, all K vectors) and **`LanczosBasisIter`** (O(dim) memory generator with operator-by-reference replay)
- **`lanczos_eig`** with `Which` enum (SA/LA/SM) and residual computation
- **FTLM**: `ftlm_partition` and `ftlm_observable` — composable pure functions on eigendecomposition data
- **LTLM**: `ltlm_coeffs` — Krylov-space coefficients for `e^{-βH/2}|r⟩`, composed with `lin_comb` at the call site
- **FTLMDynamic**: `continued_fraction` resolvent + `ftlm_dynamic_spectral` for spectral functions
- **Python bindings**: `EigSolver`, `FTLM`, `LTLM`, `FTLMDynamic` classes with GIL release
- **Type stubs** updated in `_rs.pyi`
- **30 Rust unit tests**, all existing tests unaffected

### Key design decisions (from #9 review)
- No new dependencies — `nalgebra` (already in workspace) handles the small dense eigenproblem
- In-place matvec with pre-allocated buffers matching existing `Hamiltonian::dot` pattern
- No standalone `expm_krylov` or `KrylovPropagator` — existing `expm_dot` and `SchrodingerEq` cover those use cases
- ARPACK via Python (`scipy.sparse.linalg.eigsh`) for implicit restarts and interior eigenvalues

## Test plan

- [x] `cargo test -p quspin-core` — 262 tests pass (30 new krylov tests)
- [x] `cargo clippy -p quspin-core -p quspin-py --all-targets -- -D warnings` — clean
- [x] `uv run pytest python/tests/ -v -m "not slow"` — 107 tests pass
- [x] Manual verification of Python bindings (EigSolver, FTLM, LTLM)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)