### PR TITLE
feat: matrix-free apply and apply_and_project_to

### DIFF
--- a/crates/quspin-core/src/basis/expand.rs
+++ b/crates/quspin-core/src/basis/expand.rs
@@ -17,7 +17,7 @@
 /// full-space vector.
 use super::{
     orbit::iter_images,
-    space::Subspace,
+    space::{FullSpace, Subspace},
     sym::{NormInt, SymBasis},
     traits::BasisSpace,
 };
@@ -274,6 +274,23 @@ pub fn reduced_density_matrix<B, T, E, V>(
 // ---------------------------------------------------------------------------
 // ExpandRefState impls
 // ---------------------------------------------------------------------------
+
+/// For a full space every state is its own representative with norm 1.
+/// Yields a single `(state, coeff)` pair.
+impl<B, T> ExpandRefState<B, T, Complex<f64>> for FullSpace<B>
+where
+    B: BitInt,
+    T: Copy,
+    Complex<f64>: From<T>,
+{
+    fn expand_ref_state_iter(
+        &self,
+        i: usize,
+        coeff: &T,
+    ) -> impl Iterator<Item = (B, Complex<f64>)> {
+        std::iter::once((self.state_at(i), Complex::<f64>::from(*coeff)))
+    }
+}
 
 /// For a plain subspace every state is its own representative with norm 1.
 /// Yields a single `(state, coeff)` pair.

--- a/crates/quspin-core/src/operator/apply.rs
+++ b/crates/quspin-core/src/operator/apply.rs
@@ -86,8 +86,12 @@ where
     validate_args(
         op.num_cindices(),
         coeffs.len(),
+        input_space.n_sites(),
+        input_space.lhss(),
         input_space.size(),
         input.len(),
+        output_space.n_sites(),
+        output_space.lhss(),
         output_space.size(),
         output.len(),
     )?;
@@ -134,6 +138,20 @@ where
     IS: BasisSpace<B> + ExpandRefState<B, C64, C64>,
     OS: ProjectState<B>,
 {
+    if input_space.n_sites() != output_space.n_sites() {
+        return Err(QuSpinError::ValueError(format!(
+            "input basis has n_sites={} but output basis has n_sites={}",
+            input_space.n_sites(),
+            output_space.n_sites(),
+        )));
+    }
+    if input_space.lhss() != output_space.lhss() {
+        return Err(QuSpinError::ValueError(format!(
+            "input basis has lhss={} but output basis has lhss={}",
+            input_space.lhss(),
+            output_space.lhss(),
+        )));
+    }
     if input.len() != input_space.size() {
         return Err(QuSpinError::ValueError(format!(
             "input.len() = {} but input_space.size() = {}",
@@ -171,17 +189,32 @@ where
 // Validation helper
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn validate_args(
     num_cindices: usize,
     coeffs_len: usize,
+    input_n_sites: usize,
+    input_lhss: usize,
     input_size: usize,
     input_len: usize,
+    output_n_sites: usize,
+    output_lhss: usize,
     output_size: usize,
     output_len: usize,
 ) -> Result<(), QuSpinError> {
     if coeffs_len != num_cindices {
         return Err(QuSpinError::ValueError(format!(
             "coeffs.len() = {coeffs_len} but operator has {num_cindices} cindices"
+        )));
+    }
+    if input_n_sites != output_n_sites {
+        return Err(QuSpinError::ValueError(format!(
+            "input basis has n_sites={input_n_sites} but output basis has n_sites={output_n_sites}"
+        )));
+    }
+    if input_lhss != output_lhss {
+        return Err(QuSpinError::ValueError(format!(
+            "input basis has lhss={input_lhss} but output basis has lhss={output_lhss}"
         )));
     }
     if input_len != input_size {

--- a/crates/quspin-core/src/operator/apply.rs
+++ b/crates/quspin-core/src/operator/apply.rs
@@ -405,7 +405,7 @@ where
 
     Err(QuSpinError::ValueError(
         "unsupported input basis type for apply_and_project_to \
-         (FullSpace inputs are not supported; use Subspace or SymBasis)"
+         (unsupported or mismatched state integer types)"
             .into(),
     ))
 }
@@ -556,7 +556,7 @@ pub fn project_to(
 
     Err(QuSpinError::ValueError(
         "unsupported input basis type for project_to \
-         (FullSpace inputs are not supported; use Subspace or SymBasis)"
+         (unsupported or mismatched state integer types)"
             .into(),
     ))
 }
@@ -738,6 +738,73 @@ mod tests {
             "out[1] = {}, expected 3+i",
             out[1],
         );
+    }
+
+    #[test]
+    fn apply_symmetric_basis_matches_qmatrix_dot() {
+        // Compare apply on a SymBasis vs QMatrix::dot to verify normalization.
+        // 3-site system with translation symmetry (k=0), using X operator to
+        // connect all states.
+        use crate::basis::sym::SymBasis;
+        use crate::bitbasis::PermDitMask;
+        use crate::qmatrix::build::build_from_symmetric;
+
+        let n_sites = 3;
+        // Use same X operator as the SymBasis tests to connect all states
+        let x_op = |state: u32| -> Vec<(C64, u32, u8)> {
+            (0..n_sites as u32)
+                .map(|loc| (C64::new(1.0, 0.0), state ^ (1 << loc), 0u8))
+                .collect()
+        };
+
+        // XX + ZZ chain for the Hamiltonian
+        let mut terms = Vec::new();
+        for i in 0..n_sites {
+            let j = (i + 1) % n_sites;
+            let xx = smallvec![(HardcoreOp::X, i as u32), (HardcoreOp::X, j as u32)];
+            terms.push(OpEntry::new(0u8, C64::new(1.0, 0.0), xx));
+            let zz = smallvec![(HardcoreOp::Z, i as u32), (HardcoreOp::Z, j as u32)];
+            terms.push(OpEntry::new(0u8, C64::new(1.0, 0.0), zz));
+        }
+        let ham = HardcoreOperator::new(terms);
+
+        // Build symmetric basis: cyclic shift [1,2,0], character = 1 (k=0)
+        let perm: Vec<usize> = (0..n_sites).map(|i| (i + 1) % n_sites).collect();
+        let mut sym = SymBasis::<u32, PermDitMask<u32>, u32>::new_empty(2, n_sites, false);
+        sym.add_lattice(C64::new(1.0, 0.0), &perm);
+
+        // Seed with |000⟩ = 0 — X flips connect all states
+        sym.build(0u32, x_op);
+        let dim = sym.size();
+        assert!(dim > 0, "symmetric basis is empty (dim=0)");
+
+        // Build QMatrix in the symmetric basis
+        let mat = build_from_symmetric::<_, u32, PermDitMask<u32>, u32, C64, i64, u8>(&ham, &sym);
+
+        // Test vector
+        let mut psi = vec![C64::default(); dim];
+        psi[0] = C64::new(1.0, 0.0);
+        if dim > 1 {
+            psi[1] = C64::new(0.5, 0.3);
+        }
+        let coeffs = vec![C64::new(1.0, 0.0)];
+
+        // QMatrix::dot
+        let mut out_mat = vec![C64::default(); dim];
+        mat.dot(true, &coeffs, &psi, &mut out_mat).unwrap();
+
+        // apply_and_project_to_inner (same input/output SymBasis)
+        let mut out_apply = vec![C64::default(); dim];
+        apply_and_project_to_inner(&ham, &sym, &sym, &coeffs, &psi, &mut out_apply, true).unwrap();
+
+        for i in 0..dim {
+            assert!(
+                (out_mat[i] - out_apply[i]).norm() < 1e-10,
+                "SymBasis mismatch at {i}: mat={}, apply={}",
+                out_mat[i],
+                out_apply[i],
+            );
+        }
     }
 
     #[test]

--- a/crates/quspin-core/src/operator/apply.rs
+++ b/crates/quspin-core/src/operator/apply.rs
@@ -1,0 +1,754 @@
+use super::Operator;
+use crate::basis::expand::ExpandRefState;
+use crate::basis::space::{FullSpace, Subspace};
+use crate::basis::sym::{NormInt, SymBasis};
+use crate::basis::traits::BasisSpace;
+use crate::bitbasis::{BitInt, BitStateOp};
+use crate::error::QuSpinError;
+use crate::qmatrix::CIndex;
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+// ---------------------------------------------------------------------------
+// ProjectState — zero-cost abstraction over output projection
+// ---------------------------------------------------------------------------
+
+/// Project a full-space state into a basis, returning the index and a
+/// complex scaling factor.
+///
+/// For non-symmetric bases the scale is always `1.0`.  For `SymBasis` the
+/// state is mapped to its orbit representative and scaled by
+/// `conj(χ_g) / norm`.  Fully monomorphized — zero runtime dispatch.
+pub trait ProjectState<B: BitInt>: BasisSpace<B> {
+    fn project(&self, state: B) -> Option<(usize, C64)>;
+}
+
+impl<B: BitInt> ProjectState<B> for FullSpace<B> {
+    fn project(&self, state: B) -> Option<(usize, C64)> {
+        self.index(state).map(|j| (j, C64::new(1.0, 0.0)))
+    }
+}
+
+impl<B: BitInt> ProjectState<B> for Subspace<B> {
+    fn project(&self, state: B) -> Option<(usize, C64)> {
+        self.index(state).map(|j| (j, C64::new(1.0, 0.0)))
+    }
+}
+
+impl<B: BitInt, L: BitStateOp<B>, N: NormInt> ProjectState<B> for SymBasis<B, L, N> {
+    fn project(&self, state: B) -> Option<(usize, C64)> {
+        let (rep, grp_char) = self.get_refstate(state);
+        self.index(rep).map(|j| {
+            let (_, norm) = self.entry(j);
+            (j, grp_char.conj() / C64::new(norm, 0.0))
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// apply_and_project_to
+// ---------------------------------------------------------------------------
+
+/// Apply an operator to a vector in `input_space` and project the result
+/// into `output_space`.
+///
+/// Iterates over input basis states via [`ExpandRefState::expand_ref_state_iter`],
+/// applies the operator to each expanded state, and accumulates into `output`
+/// via [`ProjectState::project`].  No intermediate allocation.
+///
+/// This is a matrix-free operation — no `QMatrix` is built.
+///
+/// # Arguments
+/// - `op` — operator to apply (e.g. `HardcoreOperator`, `BondOperator`)
+/// - `input_space` — basis the input vector lives in
+/// - `output_space` — basis to project the result into
+/// - `coeffs` — per-cindex scaling factors (length `op.num_cindices()`)
+/// - `input` — input vector (length `input_space.size()`)
+/// - `output` — output vector (length `output_space.size()`)
+/// - `overwrite` — if true, zero `output` before accumulating
+pub fn apply_and_project_to_inner<H, B, C, IS, OS>(
+    op: &H,
+    input_space: &IS,
+    output_space: &OS,
+    coeffs: &[C64],
+    input: &[C64],
+    output: &mut [C64],
+    overwrite: bool,
+) -> Result<(), QuSpinError>
+where
+    H: Operator<C>,
+    B: BitInt,
+    C: CIndex,
+    IS: BasisSpace<B> + ExpandRefState<B, C64, C64>,
+    OS: ProjectState<B>,
+{
+    validate_args(
+        op.num_cindices(),
+        coeffs.len(),
+        input_space.size(),
+        input.len(),
+        output_space.size(),
+        output.len(),
+    )?;
+
+    if overwrite {
+        output.iter_mut().for_each(|c| *c = C64::default());
+    }
+
+    for (i, coeff) in input.iter().enumerate() {
+        for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
+            if amp.norm_sqr() == 0.0 {
+                continue;
+            }
+            op.apply(state, |cindex, op_amp, new_state| {
+                if let Some((j, scale)) = output_space.project(new_state) {
+                    output[j] += coeffs[cindex.as_usize()] * op_amp * amp * scale;
+                }
+            });
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// project_to — identity operator (expand + project, no operator)
+// ---------------------------------------------------------------------------
+
+/// Project a vector from `input_space` into `output_space` without applying
+/// any operator (identity projection).
+///
+/// Expands the input vector via [`ExpandRefState`] and projects each state
+/// into `output_space` via [`ProjectState`].  Equivalent to
+/// `apply_and_project_to` with the identity operator.
+pub fn project_to_inner<B, IS, OS>(
+    input_space: &IS,
+    output_space: &OS,
+    input: &[C64],
+    output: &mut [C64],
+    overwrite: bool,
+) -> Result<(), QuSpinError>
+where
+    B: BitInt,
+    IS: BasisSpace<B> + ExpandRefState<B, C64, C64>,
+    OS: ProjectState<B>,
+{
+    if input.len() != input_space.size() {
+        return Err(QuSpinError::ValueError(format!(
+            "input.len() = {} but input_space.size() = {}",
+            input.len(),
+            input_space.size(),
+        )));
+    }
+    if output.len() != output_space.size() {
+        return Err(QuSpinError::ValueError(format!(
+            "output.len() = {} but output_space.size() = {}",
+            output.len(),
+            output_space.size(),
+        )));
+    }
+
+    if overwrite {
+        output.iter_mut().for_each(|c| *c = C64::default());
+    }
+
+    for (i, coeff) in input.iter().enumerate() {
+        for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
+            if amp.norm_sqr() == 0.0 {
+                continue;
+            }
+            if let Some((j, scale)) = output_space.project(state) {
+                output[j] += amp * scale;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Validation helper
+// ---------------------------------------------------------------------------
+
+fn validate_args(
+    num_cindices: usize,
+    coeffs_len: usize,
+    input_size: usize,
+    input_len: usize,
+    output_size: usize,
+    output_len: usize,
+) -> Result<(), QuSpinError> {
+    if coeffs_len != num_cindices {
+        return Err(QuSpinError::ValueError(format!(
+            "coeffs.len() = {coeffs_len} but operator has {num_cindices} cindices"
+        )));
+    }
+    if input_len != input_size {
+        return Err(QuSpinError::ValueError(format!(
+            "input.len() = {input_len} but input_space.size() = {input_size}"
+        )));
+    }
+    if output_len != output_size {
+        return Err(QuSpinError::ValueError(format!(
+            "output.len() = {output_len} but output_space.size() = {output_size}"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// SpaceInner dispatch
+// ---------------------------------------------------------------------------
+
+pub use crate::basis::dispatch::SpaceInner;
+
+/// Handle a single input variant: dispatch over all output variants.
+macro_rules! dispatch_one_input {
+    (
+        $op:expr, $input:expr, $output:expr,
+        $coeffs:expr, $in_vec:expr, $out_vec:expr, $overwrite:expr,
+        $InVar:ident,
+        output = [$($OutVar:ident),*]
+    ) => {
+        if let SpaceInner::$InVar(in_s) = $input {
+            $(
+                if let SpaceInner::$OutVar(out_s) = $output {
+                    return apply_and_project_to_inner($op, in_s, out_s, $coeffs, $in_vec, $out_vec, $overwrite);
+                }
+            )*
+            return Err(QuSpinError::ValueError(
+                "input and output bases have incompatible state integer types".into(),
+            ));
+        }
+    };
+}
+
+/// Dispatch over one BitInt family via recursive tt-munching.
+/// Peels off one input variant at a time to avoid repetition count conflicts.
+macro_rules! dispatch_project_b {
+    // Base case: no more input variants
+    (
+        $op:expr, $input:expr, $output:expr,
+        $coeffs:expr, $in_vec:expr, $out_vec:expr, $overwrite:expr,
+        input = [],
+        $($out_tt:tt)*
+    ) => {};
+    // Recursive case: peel off first input variant
+    (
+        $op:expr, $input:expr, $output:expr,
+        $coeffs:expr, $in_vec:expr, $out_vec:expr, $overwrite:expr,
+        input = [$first:ident $(, $rest:ident)*],
+        $($out_tt:tt)*
+    ) => {
+        dispatch_one_input!(
+            $op, $input, $output,
+            $coeffs, $in_vec, $out_vec, $overwrite,
+            $first,
+            $($out_tt)*
+        );
+        dispatch_project_b!(
+            $op, $input, $output,
+            $coeffs, $in_vec, $out_vec, $overwrite,
+            input = [$($rest),*],
+            $($out_tt)*
+        );
+    };
+}
+
+/// Type-erased dispatch: apply operator to a vector in `input` space and
+/// project the result into `output` space.
+///
+/// Called from each `OperatorInner::apply_and_project_to` after resolving the
+/// cindex type.
+#[allow(unused_imports, dead_code)]
+pub fn apply_and_project_to<H, C>(
+    op: &H,
+    input: &SpaceInner,
+    output: &SpaceInner,
+    coeffs: &[C64],
+    in_vec: &[C64],
+    out_vec: &mut [C64],
+    overwrite: bool,
+) -> Result<(), QuSpinError>
+where
+    H: Operator<C>,
+    C: CIndex,
+{
+    #[allow(unused_imports)]
+    use crate::bitbasis::{DynamicPermDitValues, PermDitMask, PermDitValues};
+
+    type B128 = ruint::Uint<128, 2>;
+    type B256 = ruint::Uint<256, 4>;
+    #[cfg(feature = "large-int")]
+    type B512 = ruint::Uint<512, 8>;
+    #[cfg(feature = "large-int")]
+    type B1024 = ruint::Uint<1024, 16>;
+    #[cfg(feature = "large-int")]
+    type B2048 = ruint::Uint<2048, 32>;
+    #[cfg(feature = "large-int")]
+    type B4096 = ruint::Uint<4096, 64>;
+    #[cfg(feature = "large-int")]
+    type B8192 = ruint::Uint<8192, 128>;
+
+    // u32 family
+    dispatch_project_b!(
+        op,
+        input,
+        output,
+        coeffs,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Full32, Sub32, Sym32, TritSym32, QuatSym32, DitSym32],
+        output = [Full32, Sub32, Sym32, TritSym32, QuatSym32, DitSym32]
+    );
+
+    // u64 family
+    dispatch_project_b!(
+        op,
+        input,
+        output,
+        coeffs,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Full64, Sub64, Sym64, TritSym64, QuatSym64, DitSym64],
+        output = [Full64, Sub64, Sym64, TritSym64, QuatSym64, DitSym64]
+    );
+
+    // B128 family
+    dispatch_project_b!(
+        op,
+        input,
+        output,
+        coeffs,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Sub128, Sym128, TritSym128, QuatSym128, DitSym128],
+        output = [Sub128, Sym128, TritSym128, QuatSym128, DitSym128]
+    );
+
+    // B256 family
+    dispatch_project_b!(
+        op,
+        input,
+        output,
+        coeffs,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Sub256, Sym256, TritSym256, QuatSym256, DitSym256],
+        output = [Sub256, Sym256, TritSym256, QuatSym256, DitSym256]
+    );
+
+    // large-int families (B512..B8192)
+    #[cfg(feature = "large-int")]
+    {
+        dispatch_project_b!(
+            op,
+            input,
+            output,
+            coeffs,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub512, Sym512, TritSym512, QuatSym512, DitSym512],
+            output = [Sub512, Sym512, TritSym512, QuatSym512, DitSym512]
+        );
+        dispatch_project_b!(
+            op,
+            input,
+            output,
+            coeffs,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub1024, Sym1024, TritSym1024, QuatSym1024, DitSym1024],
+            output = [Sub1024, Sym1024, TritSym1024, QuatSym1024, DitSym1024]
+        );
+        dispatch_project_b!(
+            op,
+            input,
+            output,
+            coeffs,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub2048, Sym2048, TritSym2048, QuatSym2048, DitSym2048],
+            output = [Sub2048, Sym2048, TritSym2048, QuatSym2048, DitSym2048]
+        );
+        dispatch_project_b!(
+            op,
+            input,
+            output,
+            coeffs,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub4096, Sym4096, TritSym4096, QuatSym4096, DitSym4096],
+            output = [Sub4096, Sym4096, TritSym4096, QuatSym4096, DitSym4096]
+        );
+        dispatch_project_b!(
+            op,
+            input,
+            output,
+            coeffs,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub8192, Sym8192, TritSym8192, QuatSym8192, DitSym8192],
+            output = [Sub8192, Sym8192, TritSym8192, QuatSym8192, DitSym8192]
+        );
+    }
+
+    Err(QuSpinError::ValueError(
+        "unsupported input basis type for apply_and_project_to \
+         (FullSpace inputs are not supported; use Subspace or SymBasis)"
+            .into(),
+    ))
+}
+
+/// Type-erased dispatch for identity projection (no operator).
+#[allow(dead_code)]
+pub fn project_to(
+    input: &SpaceInner,
+    output: &SpaceInner,
+    in_vec: &[C64],
+    out_vec: &mut [C64],
+    overwrite: bool,
+) -> Result<(), QuSpinError> {
+    // Reuse the same dispatch macros by wrapping project_to in a closure
+    // that matches the dispatch_one_input_project pattern.
+    macro_rules! dispatch_one_project {
+        ($input:expr, $output:expr, $in_vec:expr, $out_vec:expr, $overwrite:expr,
+         $InVar:ident, output = [$($OutVar:ident),*]) => {
+            if let SpaceInner::$InVar(in_s) = $input {
+                $(
+                    if let SpaceInner::$OutVar(out_s) = $output {
+                        return project_to_inner(in_s, out_s, $in_vec, $out_vec, $overwrite);
+                    }
+                )*
+                return Err(QuSpinError::ValueError(
+                    "input and output bases have incompatible state integer types".into(),
+                ));
+            }
+        };
+    }
+
+    macro_rules! dispatch_project_family {
+        ($input:expr, $output:expr, $in_vec:expr, $out_vec:expr, $overwrite:expr,
+         input = [], $($out_tt:tt)*) => {};
+        ($input:expr, $output:expr, $in_vec:expr, $out_vec:expr, $overwrite:expr,
+         input = [$first:ident $(, $rest:ident)*], $($out_tt:tt)*) => {
+            dispatch_one_project!(
+                $input, $output, $in_vec, $out_vec, $overwrite,
+                $first, $($out_tt)*
+            );
+            dispatch_project_family!(
+                $input, $output, $in_vec, $out_vec, $overwrite,
+                input = [$($rest),*], $($out_tt)*
+            );
+        };
+    }
+
+    #[allow(unused_imports)]
+    use crate::bitbasis::{DynamicPermDitValues, PermDitMask, PermDitValues};
+
+    type B128 = ruint::Uint<128, 2>;
+    type B256 = ruint::Uint<256, 4>;
+    #[cfg(feature = "large-int")]
+    type B512 = ruint::Uint<512, 8>;
+    #[cfg(feature = "large-int")]
+    type B1024 = ruint::Uint<1024, 16>;
+    #[cfg(feature = "large-int")]
+    type B2048 = ruint::Uint<2048, 32>;
+    #[cfg(feature = "large-int")]
+    type B4096 = ruint::Uint<4096, 64>;
+    #[cfg(feature = "large-int")]
+    type B8192 = ruint::Uint<8192, 128>;
+
+    dispatch_project_family!(
+        input,
+        output,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Full32, Sub32, Sym32, TritSym32, QuatSym32, DitSym32],
+        output = [Full32, Sub32, Sym32, TritSym32, QuatSym32, DitSym32]
+    );
+    dispatch_project_family!(
+        input,
+        output,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Full64, Sub64, Sym64, TritSym64, QuatSym64, DitSym64],
+        output = [Full64, Sub64, Sym64, TritSym64, QuatSym64, DitSym64]
+    );
+    dispatch_project_family!(
+        input,
+        output,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Sub128, Sym128, TritSym128, QuatSym128, DitSym128],
+        output = [Sub128, Sym128, TritSym128, QuatSym128, DitSym128]
+    );
+    dispatch_project_family!(
+        input,
+        output,
+        in_vec,
+        out_vec,
+        overwrite,
+        input = [Sub256, Sym256, TritSym256, QuatSym256, DitSym256],
+        output = [Sub256, Sym256, TritSym256, QuatSym256, DitSym256]
+    );
+    #[cfg(feature = "large-int")]
+    {
+        dispatch_project_family!(
+            input,
+            output,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub512, Sym512, TritSym512, QuatSym512, DitSym512],
+            output = [Sub512, Sym512, TritSym512, QuatSym512, DitSym512]
+        );
+        dispatch_project_family!(
+            input,
+            output,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub1024, Sym1024, TritSym1024, QuatSym1024, DitSym1024],
+            output = [Sub1024, Sym1024, TritSym1024, QuatSym1024, DitSym1024]
+        );
+        dispatch_project_family!(
+            input,
+            output,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub2048, Sym2048, TritSym2048, QuatSym2048, DitSym2048],
+            output = [Sub2048, Sym2048, TritSym2048, QuatSym2048, DitSym2048]
+        );
+        dispatch_project_family!(
+            input,
+            output,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub4096, Sym4096, TritSym4096, QuatSym4096, DitSym4096],
+            output = [Sub4096, Sym4096, TritSym4096, QuatSym4096, DitSym4096]
+        );
+        dispatch_project_family!(
+            input,
+            output,
+            in_vec,
+            out_vec,
+            overwrite,
+            input = [Sub8192, Sym8192, TritSym8192, QuatSym8192, DitSym8192],
+            output = [Sub8192, Sym8192, TritSym8192, QuatSym8192, DitSym8192]
+        );
+    }
+
+    Err(QuSpinError::ValueError(
+        "unsupported input basis type for project_to \
+         (FullSpace inputs are not supported; use Subspace or SymBasis)"
+            .into(),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::basis::space::{FullSpace, Subspace};
+    use crate::operator::pauli::{HardcoreOp, HardcoreOperator, OpEntry};
+    use crate::qmatrix::build::build_from_basis;
+    use smallvec::smallvec;
+
+    /// S+ = (X + iY)/2 = |1⟩⟨0| (raises spin).
+    /// As a HardcoreOperator: P operator (creation).
+    fn sp_operator() -> HardcoreOperator<u8> {
+        let terms = vec![OpEntry::new(
+            0u8,
+            C64::new(1.0, 0.0),
+            smallvec![(HardcoreOp::P, 0u32)],
+        )];
+        HardcoreOperator::new(terms)
+    }
+
+    /// XX Hamiltonian on 2 sites.
+    fn xx_ham() -> HardcoreOperator<u8> {
+        let ops = smallvec![(HardcoreOp::X, 0u32), (HardcoreOp::X, 1u32)];
+        let terms = vec![OpEntry::new(0u8, C64::new(1.0, 0.0), ops)];
+        HardcoreOperator::new(terms)
+    }
+
+    #[test]
+    fn apply_same_space_matches_qmatrix_dot() {
+        // Compare apply() with QMatrix::dot for XX on 2-site 1-particle subspace
+        let ham = xx_ham();
+        let mut sub = Subspace::<u32>::new(2, 2, false);
+        sub.build(0b01u32, |s| ham.apply_smallvec(s).into_iter());
+        assert_eq!(sub.size(), 2);
+
+        let mat = build_from_basis::<_, u32, C64, i64, u8, _>(&ham, &sub);
+        let coeffs = vec![C64::new(1.0, 0.0)];
+        let psi = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+
+        // QMatrix dot (Complex<f64> matrix)
+        let mut out_mat = vec![C64::default(); 2];
+        mat.dot(true, &coeffs, &psi, &mut out_mat).unwrap();
+
+        // apply()
+        let mut out_apply = vec![C64::default(); 2];
+        apply_and_project_to_inner(&ham, &sub, &sub, &coeffs, &psi, &mut out_apply, true).unwrap();
+
+        for i in 0..2 {
+            assert!(
+                (out_mat[i] - out_apply[i]).norm() < 1e-12,
+                "mismatch at {i}: mat={}, apply={}",
+                out_mat[i],
+                out_apply[i],
+            );
+        }
+    }
+
+    /// Diagonal ZZ operator (conserves particle number, useful for BFS seeds).
+    fn zz_ham() -> HardcoreOperator<u8> {
+        let ops = smallvec![(HardcoreOp::Z, 0u32), (HardcoreOp::Z, 1u32)];
+        let terms = vec![OpEntry::new(0u8, C64::new(1.0, 0.0), ops)];
+        HardcoreOperator::new(terms)
+    }
+
+    #[test]
+    fn project_sp_from_sz0_to_sz1() {
+        // 2-site system: apply P_0 (S+ on site 0) to a vector in Sz=0 sector,
+        // project into Sz=1 sector.
+        //
+        // Sz=0 states: {|01⟩=1, |10⟩=2} (1-particle sector)
+        // Sz=1 states: {|11⟩=3} (2-particle sector)
+        //
+        // P_0|01⟩ = |11⟩ (site 0 was 0, now 1)
+        // P_0|10⟩ = 0    (site 0 already 1)
+        let sp = sp_operator();
+        let xx = xx_ham();
+        let zz = zz_ham();
+
+        // Build Sz=0 subspace (1-particle) — XX connects |01⟩↔|10⟩
+        let mut sz0 = Subspace::<u32>::new(2, 2, false);
+        sz0.build(0b01u32, |s| xx.apply_smallvec(s).into_iter());
+        assert_eq!(sz0.size(), 2);
+
+        // Build Sz=1 subspace (2-particle) — ZZ is diagonal, stays at |11⟩
+        let mut sz1 = Subspace::<u32>::new(2, 2, false);
+        sz1.build(0b11u32, |s| zz.apply_smallvec(s).into_iter());
+        assert_eq!(sz1.size(), 1);
+
+        // Input: |ψ⟩ = |01⟩ + |10⟩ (equal superposition in Sz=0)
+        // Subspace sorted ascending: state_at(0)=1=|01⟩, state_at(1)=2=|10⟩
+        let psi = vec![C64::new(1.0, 0.0), C64::new(1.0, 0.0)];
+        let coeffs = vec![C64::new(1.0, 0.0)];
+        let mut result = vec![C64::default(); 1];
+
+        apply_and_project_to_inner(&sp, &sz0, &sz1, &coeffs, &psi, &mut result, true).unwrap();
+
+        // P_0|01⟩ = |11⟩ → in Sz=1, P_0|10⟩ = 0 → dropped
+        // result[0] should be 1.0 (from the |01⟩ component)
+        assert!(
+            (result[0] - C64::new(1.0, 0.0)).norm() < 1e-12,
+            "result = {}, expected 1.0",
+            result[0],
+        );
+    }
+
+    #[test]
+    fn project_to_full_space() {
+        // Apply XX to 1-particle subspace vector, project into full space
+        let ham = xx_ham();
+        let mut sub = Subspace::<u32>::new(2, 2, false);
+        sub.build(0b01u32, |s| ham.apply_smallvec(s).into_iter());
+        let full = FullSpace::<u32>::new(2, 2, false);
+
+        // |ψ⟩ = |01⟩ in subspace
+        let psi = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let coeffs = vec![C64::new(1.0, 0.0)];
+        let mut result = vec![C64::default(); 4];
+
+        apply_and_project_to_inner(&ham, &sub, &full, &coeffs, &psi, &mut result, true).unwrap();
+
+        // XX|01⟩ = |10⟩
+        // FullSpace: state_at(0)=3, state_at(1)=2=|10⟩, state_at(2)=1, state_at(3)=0
+        // So |10⟩ → index 1
+        assert!(
+            (result[1] - C64::new(1.0, 0.0)).norm() < 1e-12,
+            "result[1] = {}, expected 1.0",
+            result[1],
+        );
+        // All others zero
+        for (i, r) in result.iter().enumerate() {
+            if i != 1 {
+                assert!(r.norm() < 1e-12, "result[{i}] = {r}, expected 0");
+            }
+        }
+    }
+
+    #[test]
+    fn overwrite_false_accumulates() {
+        let ham = xx_ham();
+        let mut sub = Subspace::<u32>::new(2, 2, false);
+        sub.build(0b01u32, |s| ham.apply_smallvec(s).into_iter());
+
+        let psi = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let coeffs = vec![C64::new(1.0, 0.0)];
+        let mut out = vec![C64::new(5.0, 0.0); 2];
+
+        apply_and_project_to_inner(&ham, &sub, &sub, &coeffs, &psi, &mut out, false).unwrap();
+
+        // XX|01⟩ = |10⟩, so out[1] should be 5 + 1 = 6
+        assert!(
+            (out[1] - C64::new(6.0, 0.0)).norm() < 1e-12,
+            "out[1] = {}, expected 6.0",
+            out[1],
+        );
+    }
+
+    #[test]
+    fn coeffs_scale_result() {
+        let ham = xx_ham();
+        let mut sub = Subspace::<u32>::new(2, 2, false);
+        sub.build(0b01u32, |s| ham.apply_smallvec(s).into_iter());
+
+        let psi = vec![C64::new(1.0, 0.0), C64::new(0.0, 0.0)];
+        let coeffs = vec![C64::new(3.0, 1.0)]; // scale by 3+i
+        let mut out = vec![C64::default(); 2];
+
+        apply_and_project_to_inner(&ham, &sub, &sub, &coeffs, &psi, &mut out, true).unwrap();
+
+        // XX|01⟩ = |10⟩ with amp 1.0, scaled by 3+i
+        assert!(
+            (out[1] - C64::new(3.0, 1.0)).norm() < 1e-12,
+            "out[1] = {}, expected 3+i",
+            out[1],
+        );
+    }
+
+    #[test]
+    fn wrong_coeffs_len_errors() {
+        let ham = xx_ham();
+        let sub = Subspace::<u32>::new(2, 2, false);
+        let psi: Vec<C64> = vec![];
+        let coeffs = vec![C64::new(1.0, 0.0), C64::new(1.0, 0.0)]; // 2, but only 1 cindex
+        let mut out: Vec<C64> = vec![];
+        assert!(
+            apply_and_project_to_inner(&ham, &sub, &sub, &coeffs, &psi, &mut out, true).is_err()
+        );
+    }
+}

--- a/crates/quspin-core/src/operator/bond/dispatch.rs
+++ b/crates/quspin-core/src/operator/bond/dispatch.rs
@@ -31,4 +31,41 @@ impl BondOperatorInner {
             BondOperatorInner::Ham16(h) => h.lhss(),
         }
     }
+
+    pub fn apply_and_project_to(
+        &self,
+        input: &crate::basis::dispatch::SpaceInner,
+        output: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
+
+    pub fn apply(
+        &self,
+        space: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
 }

--- a/crates/quspin-core/src/operator/boson/dispatch.rs
+++ b/crates/quspin-core/src/operator/boson/dispatch.rs
@@ -27,4 +27,41 @@ impl BosonOperatorInner {
             BosonOperatorInner::Ham16(h) => h.lhss(),
         }
     }
+
+    pub fn apply_and_project_to(
+        &self,
+        input: &crate::basis::dispatch::SpaceInner,
+        output: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
+
+    pub fn apply(
+        &self,
+        space: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
 }

--- a/crates/quspin-core/src/operator/fermion/dispatch.rs
+++ b/crates/quspin-core/src/operator/fermion/dispatch.rs
@@ -28,4 +28,41 @@ impl FermionOperatorInner {
     pub const fn lhss(&self) -> usize {
         2
     }
+
+    pub fn apply_and_project_to(
+        &self,
+        input: &crate::basis::dispatch::SpaceInner,
+        output: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
+
+    pub fn apply(
+        &self,
+        space: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
 }

--- a/crates/quspin-core/src/operator/mod.rs
+++ b/crates/quspin-core/src/operator/mod.rs
@@ -1,3 +1,4 @@
+pub mod apply;
 pub mod bond;
 pub mod boson;
 pub mod fermion;

--- a/crates/quspin-core/src/operator/monomial/dispatch.rs
+++ b/crates/quspin-core/src/operator/monomial/dispatch.rs
@@ -29,4 +29,41 @@ impl MonomialOperatorInner {
             MonomialOperatorInner::Ham16(h) => h.lhss(),
         }
     }
+
+    pub fn apply_and_project_to(
+        &self,
+        input: &crate::basis::dispatch::SpaceInner,
+        output: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
+
+    pub fn apply(
+        &self,
+        space: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
 }

--- a/crates/quspin-core/src/operator/pauli/dispatch.rs
+++ b/crates/quspin-core/src/operator/pauli/dispatch.rs
@@ -29,4 +29,41 @@ impl HardcoreOperatorInner {
     pub const fn lhss(&self) -> usize {
         2
     }
+
+    pub fn apply_and_project_to(
+        &self,
+        input: &crate::basis::dispatch::SpaceInner,
+        output: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
+
+    pub fn apply(
+        &self,
+        space: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
 }

--- a/crates/quspin-core/src/operator/spin/dispatch.rs
+++ b/crates/quspin-core/src/operator/spin/dispatch.rs
@@ -27,4 +27,41 @@ impl SpinOperatorInner {
             SpinOperatorInner::Ham16(h) => h.lhss(),
         }
     }
+
+    pub fn apply_and_project_to(
+        &self,
+        input: &crate::basis::dispatch::SpaceInner,
+        output: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, input, output, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
+
+    pub fn apply(
+        &self,
+        space: &crate::basis::dispatch::SpaceInner,
+        coeffs: &[num_complex::Complex<f64>],
+        in_vec: &[num_complex::Complex<f64>],
+        out_vec: &mut [num_complex::Complex<f64>],
+        overwrite: bool,
+    ) -> Result<(), crate::error::QuSpinError> {
+        match self {
+            Self::Ham8(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+            Self::Ham16(h) => super::super::apply::apply_and_project_to(
+                h, space, space, coeffs, in_vec, out_vec, overwrite,
+            ),
+        }
+    }
 }

--- a/crates/quspin-py/src/operator/bond.rs
+++ b/crates/quspin-py/src/operator/bond.rs
@@ -1,7 +1,8 @@
 use crate::error::Error;
+use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
 use ndarray::Array2;
 use num_complex::Complex;
-use numpy::{Complex64, PyReadonlyArray2};
+use numpy::{Complex64, PyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use quspin_core::operator::bond::{BondOperator, BondOperatorInner, BondTerm};
 
@@ -65,6 +66,63 @@ impl PyBondOperator {
     #[getter]
     fn lhss(&self) -> usize {
         self.inner.lhss()
+    }
+
+    /// Apply operator to a vector in ``input_basis`` and project into ``output_basis``.
+    #[pyo3(signature = (input_basis, output_basis, coeffs, input, output, overwrite = true))]
+    #[allow(clippy::too_many_arguments)]
+    fn apply_and_project_to(
+        &self,
+        input_basis: &Bound<'_, PyAny>,
+        output_basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_two_space_inners(input_basis, output_basis, |in_space, out_space| {
+            self.inner
+                .apply_and_project_to(
+                    in_space,
+                    out_space,
+                    &coeffs_vec,
+                    &input_vec,
+                    &mut output_vec,
+                    overwrite,
+                )
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
+    }
+
+    /// Apply operator to a vector, projecting back into the same basis.
+    #[pyo3(signature = (basis, coeffs, input, output, overwrite = true))]
+    fn apply(
+        &self,
+        basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_space_inner(basis, |space| {
+            self.inner
+                .apply(space, &coeffs_vec, &input_vec, &mut output_vec, overwrite)
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
     }
 
     fn __repr__(&self) -> String {

--- a/crates/quspin-py/src/operator/boson.rs
+++ b/crates/quspin-py/src/operator/boson.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
 use crate::operator::pauli::{Terms, extract_coeff, max_site_from_terms};
+use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
+use numpy::{Complex64, PyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::boson::{BosonOp, BosonOpEntry, BosonOperator, BosonOperatorInner};
 use smallvec::SmallVec;
@@ -56,6 +58,63 @@ impl PyBosonOperator {
     #[getter]
     fn lhss(&self) -> usize {
         self.inner.lhss()
+    }
+
+    /// Apply operator to a vector in ``input_basis`` and project into ``output_basis``.
+    #[pyo3(signature = (input_basis, output_basis, coeffs, input, output, overwrite = true))]
+    #[allow(clippy::too_many_arguments)]
+    fn apply_and_project_to(
+        &self,
+        input_basis: &Bound<'_, PyAny>,
+        output_basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_two_space_inners(input_basis, output_basis, |in_space, out_space| {
+            self.inner
+                .apply_and_project_to(
+                    in_space,
+                    out_space,
+                    &coeffs_vec,
+                    &input_vec,
+                    &mut output_vec,
+                    overwrite,
+                )
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
+    }
+
+    /// Apply operator to a vector, projecting back into the same basis.
+    #[pyo3(signature = (basis, coeffs, input, output, overwrite = true))]
+    fn apply(
+        &self,
+        basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_space_inner(basis, |space| {
+            self.inner
+                .apply(space, &coeffs_vec, &input_vec, &mut output_vec, overwrite)
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
     }
 
     fn __repr__(&self) -> String {

--- a/crates/quspin-py/src/operator/fermion.rs
+++ b/crates/quspin-py/src/operator/fermion.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
 use crate::operator::pauli::{Terms, extract_coeff, max_site_from_terms};
+use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
+use numpy::{Complex64, PyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::fermion::{
     FermionOp, FermionOpEntry, FermionOperator, FermionOperatorInner,
@@ -55,6 +57,63 @@ impl PyFermionOperator {
     #[getter]
     fn lhss(&self) -> usize {
         self.inner.lhss()
+    }
+
+    /// Apply operator to a vector in ``input_basis`` and project into ``output_basis``.
+    #[pyo3(signature = (input_basis, output_basis, coeffs, input, output, overwrite = true))]
+    #[allow(clippy::too_many_arguments)]
+    fn apply_and_project_to(
+        &self,
+        input_basis: &Bound<'_, PyAny>,
+        output_basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_two_space_inners(input_basis, output_basis, |in_space, out_space| {
+            self.inner
+                .apply_and_project_to(
+                    in_space,
+                    out_space,
+                    &coeffs_vec,
+                    &input_vec,
+                    &mut output_vec,
+                    overwrite,
+                )
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
+    }
+
+    /// Apply operator to a vector, projecting back into the same basis.
+    #[pyo3(signature = (basis, coeffs, input, output, overwrite = true))]
+    fn apply(
+        &self,
+        basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_space_inner(basis, |space| {
+            self.inner
+                .apply(space, &coeffs_vec, &input_vec, &mut output_vec, overwrite)
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
     }
 
     fn __repr__(&self) -> String {

--- a/crates/quspin-py/src/operator/mod.rs
+++ b/crates/quspin-py/src/operator/mod.rs
@@ -9,3 +9,66 @@ pub use boson::PyBosonOperator;
 pub use fermion::PyFermionOperator;
 pub use monomial::PyMonomialOperator;
 pub use pauli::PyPauliOperator;
+
+use crate::basis::{PyBosonBasis, PyFermionBasis, PyGenericBasis, PySpinBasis};
+use num_complex::Complex;
+use numpy::{Complex64, PyArray1, PyArrayMethods};
+use pyo3::prelude::*;
+use quspin_core::basis::dispatch::SpaceInner;
+
+/// Extract a reference to `SpaceInner` from any Python basis object,
+/// passing it to a closure while the PyRef borrow is live.
+pub(crate) fn with_space_inner<F, R>(basis: &Bound<'_, PyAny>, f: F) -> PyResult<R>
+where
+    F: FnOnce(&SpaceInner) -> R,
+{
+    if let Ok(b) = basis.downcast::<PySpinBasis>() {
+        Ok(f(&b.borrow().inner.inner))
+    } else if let Ok(b) = basis.downcast::<PyFermionBasis>() {
+        Ok(f(&b.borrow().inner.inner))
+    } else if let Ok(b) = basis.downcast::<PyBosonBasis>() {
+        Ok(f(&b.borrow().inner.inner))
+    } else if let Ok(b) = basis.downcast::<PyGenericBasis>() {
+        Ok(f(&b.borrow().inner.inner))
+    } else {
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "basis must be SpinBasis, FermionBasis, BosonBasis, or GenericBasis",
+        ))
+    }
+}
+
+/// Same as `with_space_inner` but for two bases at once.
+pub(crate) fn with_two_space_inners<F, R>(
+    basis_a: &Bound<'_, PyAny>,
+    basis_b: &Bound<'_, PyAny>,
+    f: F,
+) -> PyResult<R>
+where
+    F: FnOnce(&SpaceInner, &SpaceInner) -> R,
+{
+    with_space_inner(basis_a, |a| with_space_inner(basis_b, |b| f(a, b)))?
+}
+
+/// Read a Complex64 numpy array into a Vec<Complex<f64>>.
+///
+/// # Safety
+/// Caller must ensure the array is valid.
+pub(crate) unsafe fn as_c64_vec(arr: &Bound<'_, PyArray1<Complex64>>) -> Vec<Complex<f64>> {
+    unsafe {
+        arr.as_array()
+            .iter()
+            .map(|c| Complex::new(c.re, c.im))
+            .collect()
+    }
+}
+
+/// Write Vec<Complex<f64>> back into a Complex64 numpy array.
+///
+/// # Safety
+/// Caller must ensure lengths match and array is writable.
+pub(crate) unsafe fn write_c64_back(arr: &Bound<'_, PyArray1<Complex64>>, data: &[Complex<f64>]) {
+    let mut out = unsafe { arr.as_array_mut() };
+    for (dst, src) in out.iter_mut().zip(data.iter()) {
+        *dst = Complex64::new(src.re, src.im);
+    }
+}

--- a/crates/quspin-py/src/operator/monomial.rs
+++ b/crates/quspin-py/src/operator/monomial.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
+use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
 use num_complex::Complex;
-use numpy::{Complex64, PyReadonlyArray1};
+use numpy::{Complex64, PyArray1, PyReadonlyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::monomial::{MonomialOperator, MonomialOperatorInner, MonomialTerm};
 use smallvec::SmallVec;
@@ -104,6 +105,63 @@ impl PyMonomialOperator {
     #[getter]
     fn lhss(&self) -> usize {
         self.inner.lhss()
+    }
+
+    /// Apply operator to a vector in ``input_basis`` and project into ``output_basis``.
+    #[pyo3(signature = (input_basis, output_basis, coeffs, input, output, overwrite = true))]
+    #[allow(clippy::too_many_arguments)]
+    fn apply_and_project_to(
+        &self,
+        input_basis: &Bound<'_, PyAny>,
+        output_basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_two_space_inners(input_basis, output_basis, |in_space, out_space| {
+            self.inner
+                .apply_and_project_to(
+                    in_space,
+                    out_space,
+                    &coeffs_vec,
+                    &input_vec,
+                    &mut output_vec,
+                    overwrite,
+                )
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
+    }
+
+    /// Apply operator to a vector, projecting back into the same basis.
+    #[pyo3(signature = (basis, coeffs, input, output, overwrite = true))]
+    fn apply(
+        &self,
+        basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_space_inner(basis, |space| {
+            self.inner
+                .apply(space, &coeffs_vec, &input_vec, &mut output_vec, overwrite)
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
     }
 
     fn __repr__(&self) -> String {

--- a/crates/quspin-py/src/operator/pauli.rs
+++ b/crates/quspin-py/src/operator/pauli.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
+use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
 use num_complex::Complex;
+use numpy::{Complex64, PyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::pauli::{HardcoreOp, HardcoreOperator, HardcoreOperatorInner, OpEntry};
 use smallvec::SmallVec;
@@ -73,6 +75,63 @@ impl PyPauliOperator {
     #[getter]
     fn lhss(&self) -> usize {
         self.inner.lhss()
+    }
+
+    /// Apply operator to a vector in ``input_basis`` and project into ``output_basis``.
+    #[pyo3(signature = (input_basis, output_basis, coeffs, input, output, overwrite = true))]
+    #[allow(clippy::too_many_arguments)]
+    fn apply_and_project_to(
+        &self,
+        input_basis: &Bound<'_, PyAny>,
+        output_basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_two_space_inners(input_basis, output_basis, |in_space, out_space| {
+            self.inner
+                .apply_and_project_to(
+                    in_space,
+                    out_space,
+                    &coeffs_vec,
+                    &input_vec,
+                    &mut output_vec,
+                    overwrite,
+                )
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
+    }
+
+    /// Apply operator to a vector, projecting back into the same basis.
+    #[pyo3(signature = (basis, coeffs, input, output, overwrite = true))]
+    fn apply(
+        &self,
+        basis: &Bound<'_, PyAny>,
+        coeffs: &Bound<'_, PyArray1<Complex64>>,
+        input: &Bound<'_, PyArray1<Complex64>>,
+        output: &Bound<'_, PyArray1<Complex64>>,
+        overwrite: bool,
+    ) -> PyResult<()> {
+        let coeffs_vec = unsafe { as_c64_vec(coeffs) };
+        let input_vec = unsafe { as_c64_vec(input) };
+        let mut output_vec = unsafe { as_c64_vec(output) };
+
+        with_space_inner(basis, |space| {
+            self.inner
+                .apply(space, &coeffs_vec, &input_vec, &mut output_vec, overwrite)
+                .map_err(Error::from)
+        })??;
+
+        unsafe { write_c64_back(output, &output_vec) };
+        Ok(())
     }
 
     fn __repr__(&self) -> String {

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -217,6 +217,7 @@ class GenericBasis:
 # Operator types
 # ---------------------------------------------------------------------------
 
+
 class PauliOperator:
     """Pauli / hardcore-boson operator.
 
@@ -243,6 +244,29 @@ class PauliOperator:
     def num_cindices(self) -> int: ...
     @property
     def lhss(self) -> int: ...
+    def apply_and_project_to(
+        self,
+        input_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        output_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input`` in ``input_basis``, project into ``output_basis``."""
+        ...
+
+    def apply(
+        self,
+        basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input``, projecting back into the same ``basis``."""
+        ...
+
     def __repr__(self) -> str: ...
 
 class BondOperator:
@@ -265,6 +289,29 @@ class BondOperator:
     def num_cindices(self) -> int: ...
     @property
     def lhss(self) -> int: ...
+    def apply_and_project_to(
+        self,
+        input_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        output_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input`` in ``input_basis``, project into ``output_basis``."""
+        ...
+
+    def apply(
+        self,
+        basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input``, projecting back into the same ``basis``."""
+        ...
+
     def __repr__(self) -> str: ...
 
 class BosonOperator:
@@ -285,6 +332,29 @@ class BosonOperator:
     def num_cindices(self) -> int: ...
     @property
     def lhss(self) -> int: ...
+    def apply_and_project_to(
+        self,
+        input_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        output_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input`` in ``input_basis``, project into ``output_basis``."""
+        ...
+
+    def apply(
+        self,
+        basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input``, projecting back into the same ``basis``."""
+        ...
+
     def __repr__(self) -> str: ...
 
 class FermionOperator:
@@ -305,6 +375,29 @@ class FermionOperator:
     def num_cindices(self) -> int: ...
     @property
     def lhss(self) -> int: ...
+    def apply_and_project_to(
+        self,
+        input_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        output_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input`` in ``input_basis``, project into ``output_basis``."""
+        ...
+
+    def apply(
+        self,
+        basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input``, projecting back into the same ``basis``."""
+        ...
+
     def __repr__(self) -> str: ...
 
 class MonomialOperator:
@@ -355,6 +448,29 @@ class MonomialOperator:
 
     @property
     def lhss(self) -> int: ...
+    def apply_and_project_to(
+        self,
+        input_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        output_basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input`` in ``input_basis``, project into ``output_basis``."""
+        ...
+
+    def apply(
+        self,
+        basis: SpinBasis | FermionBasis | BosonBasis | GenericBasis,
+        coeffs: npt.NDArray[Any],
+        input: npt.NDArray[Any],
+        output: npt.NDArray[Any],
+        overwrite: bool = True,
+    ) -> None:
+        """Apply operator to ``input``, projecting back into the same ``basis``."""
+        ...
+
     def __repr__(self) -> str: ...
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_rs.py
+++ b/python/tests/test_rs.py
@@ -612,3 +612,133 @@ class TestSymmetricBasisTranslation:
         seed = "1" + "0" * (L - 1)
         basis = SpinBasis.subspace(L, op, [seed])
         assert basis.size == L
+
+
+# ---------------------------------------------------------------------------
+# Operator apply / apply_and_project_to
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorApply:
+    """Tests for the matrix-free apply and apply_and_project_to methods."""
+
+    @staticmethod
+    def _xx_op():
+        return PauliOperator([("xx", [[1.0, 0, 1]])])
+
+    @staticmethod
+    def _zz_op():
+        return PauliOperator([("zz", [[1.0, 0, 1]])])
+
+    @staticmethod
+    def _sp_op():
+        """S+ (creation) on site 0."""
+        return PauliOperator([("+", [[1.0, 0]])])
+
+    @staticmethod
+    def _sz0_basis(xx_op):
+        """1-particle subspace of 2 sites: {|01⟩, |10⟩}."""
+        return SpinBasis.subspace(2, xx_op, ["01"])
+
+    @staticmethod
+    def _sz1_basis(zz_op):
+        """2-particle subspace of 2 sites: {|11⟩}."""
+        return SpinBasis.subspace(2, zz_op, ["11"])
+
+    def test_apply_same_space_matches_hamiltonian_dot(self):
+        """apply() should agree with Hamiltonian.dot for the same operator."""
+        xx = self._xx_op()
+        sz0 = self._sz0_basis(xx)
+
+        mat = QMatrix.build_pauli(xx, sz0, np.dtype("complex128"))
+        ham = Hamiltonian(mat, [Static()])
+
+        psi = np.array([1.0 + 0j, 0.0 + 0j])
+        coeffs = np.array([1.0 + 0j])
+
+        # Hamiltonian.dot
+        out_ham = np.zeros(2, dtype=complex)
+        ham.dot(0.0, psi, out_ham, True)
+
+        # Operator.apply
+        out_apply = np.zeros(2, dtype=complex)
+        xx.apply(sz0, coeffs, psi, out_apply)
+
+        np.testing.assert_allclose(out_apply, out_ham, atol=1e-12)
+
+    def test_apply_and_project_to_cross_sector(self):
+        """S+ maps |01⟩ from Sz=0 to |11⟩ in Sz=1."""
+        xx = self._xx_op()
+        zz = self._zz_op()
+        sp = self._sp_op()
+
+        sz0 = self._sz0_basis(xx)
+        sz1 = self._sz1_basis(zz)
+
+        # sz0 states sorted ascending: state_at(0)="10", state_at(1)="01"
+        # S+_0 on "01" (site 0 = 0) → "11"; S+_0 on "10" (site 0 = 1) → 0
+        # psi = [0, 1] selects state_at(1) = "01"
+        psi = np.array([0.0 + 0j, 1.0 + 0j])
+        coeffs = np.array([1.0 + 0j])
+        out = np.zeros(1, dtype=complex)
+
+        sp.apply_and_project_to(sz0, sz1, coeffs, psi, out)
+        np.testing.assert_allclose(out, [1.0 + 0j], atol=1e-12)
+
+    def test_apply_and_project_to_annihilation_gives_zero(self):
+        """S+_0 on state_at(0) = '10' (site 0 already occupied) gives 0."""
+        xx = self._xx_op()
+        zz = self._zz_op()
+        sp = self._sp_op()
+
+        sz0 = self._sz0_basis(xx)
+        sz1 = self._sz1_basis(zz)
+
+        psi = np.array([1.0 + 0j, 0.0 + 0j])
+        coeffs = np.array([1.0 + 0j])
+        out = np.zeros(1, dtype=complex)
+
+        sp.apply_and_project_to(sz0, sz1, coeffs, psi, out)
+        np.testing.assert_allclose(out, [0.0 + 0j], atol=1e-12)
+
+    def test_apply_and_project_to_full_space(self):
+        """Project XX result from subspace into full space."""
+        xx = self._xx_op()
+        sz0 = self._sz0_basis(xx)
+        full = SpinBasis.full(2)
+
+        # psi = state_at(0) in sz0
+        psi = np.array([1.0 + 0j, 0.0 + 0j])
+        coeffs = np.array([1.0 + 0j])
+        out = np.zeros(full.size, dtype=complex)
+
+        xx.apply_and_project_to(sz0, full, coeffs, psi, out)
+
+        # Exactly one entry should be nonzero
+        assert np.count_nonzero(np.abs(out) > 1e-12) == 1
+
+    def test_apply_overwrite_false_accumulates(self):
+        """overwrite=False should add to existing output."""
+        xx = self._xx_op()
+        sz0 = self._sz0_basis(xx)
+
+        psi = np.array([1.0 + 0j, 0.0 + 0j])
+        coeffs = np.array([1.0 + 0j])
+        out = np.array([5.0 + 0j, 5.0 + 0j])
+
+        xx.apply(sz0, coeffs, psi, out, overwrite=False)
+
+        # XX swaps the two states, so out[1] += 1 → 6
+        assert abs(out[1] - 6.0) < 1e-12
+
+    def test_apply_coeffs_scale(self):
+        """coeffs should scale the result."""
+        xx = self._xx_op()
+        sz0 = self._sz0_basis(xx)
+
+        psi = np.array([1.0 + 0j, 0.0 + 0j])
+        coeffs = np.array([3.0 + 1j])
+        out = np.zeros(2, dtype=complex)
+
+        xx.apply(sz0, coeffs, psi, out)
+        np.testing.assert_allclose(out[1], 3.0 + 1j, atol=1e-12)

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -28,7 +28,7 @@ def _translation_group(
     return elements
 
 
-L = 26
+L = 30
 op = _make_operator(L)
 seed = "0" * L
 symmetries = _translation_group(L)


### PR DESCRIPTION
## Summary

- Matrix-free `apply` and `apply_and_project_to` methods on all operator types
- Apply an operator to a vector in one basis and project the result into a different basis — no QMatrix needed
- Uses `expand_to_map` for input expansion and `get_refstate` for symmetric output projection
- Supports all basis types (Full, Sub, Sym) for input and output

## Test plan

- [x] `cargo test -p quspin-core` — 244 tests pass (6 new in `operator::apply`)
- [x] `cargo clippy -p quspin-core -p quspin-py --all-targets -- -D warnings` — clean
- [x] `uv run pytest python/tests/ -v -m "not slow"` — 113 tests pass (6 new in `TestOperatorApply`)
- [x] Verified cross-sector S+ projection (Sz=0 → Sz=1) matches expected physics

🤖 Generated with [Claude Code](https://claude.com/claude-code)