### PR TITLE
refactor: deduplicate operator parsing in quspin-py

### DIFF
--- a/crates/quspin-py/src/operator/boson.rs
+++ b/crates/quspin-py/src/operator/boson.rs
@@ -1,10 +1,11 @@
 use crate::error::Error;
-use crate::operator::pauli::{Terms, extract_coeff, max_site_from_terms};
-use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
+use crate::operator::{
+    Terms, as_c64_vec, max_site_from_terms, parse_terms_generic, with_space_inner,
+    with_two_space_inners, write_c64_back,
+};
 use numpy::{Complex64, PyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::boson::{BosonOp, BosonOpEntry, BosonOperator, BosonOperatorInner};
-use smallvec::SmallVec;
 
 /// Python-facing bosonic operator (truncated harmonic oscillator).
 ///
@@ -29,12 +30,14 @@ impl PyBosonOperator {
         let use_u8 = max_cindex <= 255 && max_site <= 255;
 
         if use_u8 {
-            let entries = parse_terms::<u8>(py, &terms).map_err(Error::from)?;
+            let entries = parse_terms_generic::<u8, BosonOp, _, _>(py, &terms, BosonOpEntry::new)
+                .map_err(Error::from)?;
             Ok(PyBosonOperator {
                 inner: BosonOperatorInner::Ham8(BosonOperator::new(entries, lhss)),
             })
         } else if max_cindex <= 65535 && max_site <= 65535 {
-            let entries = parse_terms::<u16>(py, &terms).map_err(Error::from)?;
+            let entries = parse_terms_generic::<u16, BosonOp, _, _>(py, &terms, BosonOpEntry::new)
+                .map_err(Error::from)?;
             Ok(PyBosonOperator {
                 inner: BosonOperatorInner::Ham16(BosonOperator::new(entries, lhss)),
             })
@@ -125,61 +128,4 @@ impl PyBosonOperator {
             self.inner.num_cindices(),
         )
     }
-}
-
-fn parse_terms<C: Copy + Ord + TryFrom<usize>>(
-    py: Python<'_>,
-    terms: &[crate::operator::pauli::Term],
-) -> Result<Vec<BosonOpEntry<C>>, quspin_core::error::QuSpinError>
-where
-    <C as TryFrom<usize>>::Error: std::fmt::Debug,
-{
-    let mut entries = Vec::new();
-    for (cindex_usize, term) in terms.iter().enumerate() {
-        let cindex = C::try_from(cindex_usize).map_err(|_| {
-            quspin_core::error::QuSpinError::ValueError(format!(
-                "cindex {cindex_usize} out of range for chosen index type"
-            ))
-        })?;
-        for (op_str, bonds) in term {
-            for bond in bonds {
-                if bond.is_empty() {
-                    return Err(quspin_core::error::QuSpinError::ValueError(
-                        "each bond must be [coeff, site0, site1, ...]".to_string(),
-                    ));
-                }
-                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
-                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
-                })?;
-                let sites: Vec<u32> = bond[1..]
-                    .iter()
-                    .map(|s| {
-                        s.bind(py).extract::<u32>().map_err(|e| {
-                            quspin_core::error::QuSpinError::ValueError(format!(
-                                "bond site index: {e}"
-                            ))
-                        })
-                    })
-                    .collect::<Result<_, _>>()?;
-                if op_str.len() != sites.len() {
-                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
-                        "op_str length {} != number of sites {}",
-                        op_str.len(),
-                        sites.len()
-                    )));
-                }
-                let mut ops: SmallVec<[(BosonOp, u32); 4]> = SmallVec::new();
-                for (ch, &site) in op_str.chars().zip(sites.iter()) {
-                    let op = BosonOp::from_char(ch).ok_or_else(|| {
-                        quspin_core::error::QuSpinError::ValueError(format!(
-                            "unknown operator character '{ch}'; expected one of +, -, n"
-                        ))
-                    })?;
-                    ops.push((op, site));
-                }
-                entries.push(BosonOpEntry::new(cindex, coeff, ops));
-            }
-        }
-    }
-    Ok(entries)
 }

--- a/crates/quspin-py/src/operator/fermion.rs
+++ b/crates/quspin-py/src/operator/fermion.rs
@@ -1,12 +1,13 @@
 use crate::error::Error;
-use crate::operator::pauli::{Terms, extract_coeff, max_site_from_terms};
-use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
+use crate::operator::{
+    Terms, as_c64_vec, max_site_from_terms, parse_terms_generic, with_space_inner,
+    with_two_space_inners, write_c64_back,
+};
 use numpy::{Complex64, PyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::fermion::{
     FermionOp, FermionOpEntry, FermionOperator, FermionOperatorInner,
 };
-use smallvec::SmallVec;
 
 /// Python-facing fermionic operator.
 ///
@@ -28,12 +29,16 @@ impl PyFermionOperator {
         let use_u8 = max_cindex <= 255 && max_site <= 255;
 
         if use_u8 {
-            let entries = parse_terms::<u8>(py, &terms).map_err(Error::from)?;
+            let entries =
+                parse_terms_generic::<u8, FermionOp, _, _>(py, &terms, FermionOpEntry::new)
+                    .map_err(Error::from)?;
             Ok(PyFermionOperator {
                 inner: FermionOperatorInner::Ham8(FermionOperator::new(entries)),
             })
         } else if max_cindex <= 65535 && max_site <= 65535 {
-            let entries = parse_terms::<u16>(py, &terms).map_err(Error::from)?;
+            let entries =
+                parse_terms_generic::<u16, FermionOp, _, _>(py, &terms, FermionOpEntry::new)
+                    .map_err(Error::from)?;
             Ok(PyFermionOperator {
                 inner: FermionOperatorInner::Ham16(FermionOperator::new(entries)),
             })
@@ -123,61 +128,4 @@ impl PyFermionOperator {
             self.inner.num_cindices(),
         )
     }
-}
-
-fn parse_terms<C: Copy + Ord + TryFrom<usize>>(
-    py: Python<'_>,
-    terms: &[crate::operator::pauli::Term],
-) -> Result<Vec<FermionOpEntry<C>>, quspin_core::error::QuSpinError>
-where
-    <C as TryFrom<usize>>::Error: std::fmt::Debug,
-{
-    let mut entries = Vec::new();
-    for (cindex_usize, term) in terms.iter().enumerate() {
-        let cindex = C::try_from(cindex_usize).map_err(|_| {
-            quspin_core::error::QuSpinError::ValueError(format!(
-                "cindex {cindex_usize} out of range for chosen index type"
-            ))
-        })?;
-        for (op_str, bonds) in term {
-            for bond in bonds {
-                if bond.is_empty() {
-                    return Err(quspin_core::error::QuSpinError::ValueError(
-                        "each bond must be [coeff, site0, site1, ...]".to_string(),
-                    ));
-                }
-                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
-                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
-                })?;
-                let sites: Vec<u32> = bond[1..]
-                    .iter()
-                    .map(|s| {
-                        s.bind(py).extract::<u32>().map_err(|e| {
-                            quspin_core::error::QuSpinError::ValueError(format!(
-                                "bond site index: {e}"
-                            ))
-                        })
-                    })
-                    .collect::<Result<_, _>>()?;
-                if op_str.len() != sites.len() {
-                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
-                        "op_str length {} != number of sites {}",
-                        op_str.len(),
-                        sites.len()
-                    )));
-                }
-                let mut ops: SmallVec<[(FermionOp, u32); 4]> = SmallVec::new();
-                for (ch, &site) in op_str.chars().zip(sites.iter()) {
-                    let op = FermionOp::from_char(ch).ok_or_else(|| {
-                        quspin_core::error::QuSpinError::ValueError(format!(
-                            "unknown operator character '{ch}'; expected one of +, -, n"
-                        ))
-                    })?;
-                    ops.push((op, site));
-                }
-                entries.push(FermionOpEntry::new(cindex, coeff, ops));
-            }
-        }
-    }
-    Ok(entries)
 }

--- a/crates/quspin-py/src/operator/mod.rs
+++ b/crates/quspin-py/src/operator/mod.rs
@@ -154,10 +154,11 @@ where
                         })
                     })
                     .collect::<Result<_, _>>()?;
-                if op_str.len() != sites.len() {
+                let op_len = op_str.chars().count();
+                if op_len != sites.len() {
                     return Err(quspin_core::error::QuSpinError::ValueError(format!(
                         "op_str length {} != number of sites {}",
-                        op_str.len(),
+                        op_len,
                         sites.len()
                     )));
                 }

--- a/crates/quspin-py/src/operator/mod.rs
+++ b/crates/quspin-py/src/operator/mod.rs
@@ -14,7 +14,9 @@ use crate::basis::{PyBosonBasis, PyFermionBasis, PyGenericBasis, PySpinBasis};
 use num_complex::Complex;
 use numpy::{Complex64, PyArray1, PyArrayMethods};
 use pyo3::prelude::*;
+use quspin_core::ParseOp;
 use quspin_core::basis::dispatch::SpaceInner;
+use smallvec::SmallVec;
 
 /// Extract a reference to `SpaceInner` from any Python basis object,
 /// passing it to a closure while the PyRef borrow is live.
@@ -71,4 +73,102 @@ pub(crate) unsafe fn write_c64_back(arr: &Bound<'_, PyArray1<Complex64>>, data: 
     for (dst, src) in out.iter_mut().zip(data.iter()) {
         *dst = Complex64::new(src.re, src.im);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Shared operator-parsing helpers (used by pauli, boson, fermion)
+// ---------------------------------------------------------------------------
+
+/// A single term: a list of `(op_str, bonds)` pairs sharing one cindex.
+pub(crate) type Term = Vec<(String, Vec<Vec<PyObject>>)>;
+/// All terms passed to a constructor (one per cindex).
+pub(crate) type Terms = Vec<Term>;
+
+/// Extract the max site index from all bonds across all terms.
+pub(crate) fn max_site_from_terms(py: Python<'_>, terms: &[Term]) -> PyResult<usize> {
+    let mut max = 0usize;
+    for term in terms {
+        for (_, bonds) in term {
+            for bond in bonds {
+                // bond = [coeff, site0, site1, ...]  — skip index 0 (coeff)
+                for obj in bond.iter().skip(1) {
+                    let site: u32 = obj.bind(py).extract()?;
+                    max = max.max(site as usize);
+                }
+            }
+        }
+    }
+    Ok(max)
+}
+
+/// Extract a complex coefficient from a Python scalar (int, float, or complex).
+pub(crate) fn extract_coeff(py: Python<'_>, obj: &PyObject) -> PyResult<Complex<f64>> {
+    let bound = obj.bind(py);
+    if let Ok(z) = bound.extract::<Complex<f64>>() {
+        return Ok(z);
+    }
+    let re: f64 = bound.extract()?;
+    Ok(Complex::new(re, 0.0))
+}
+
+/// Generic parsing of `*terms` for any operator type that implements `ParseOp`.
+///
+/// The `make_entry` closure constructs the concrete entry type (e.g. `OpEntry`,
+/// `BosonOpEntry`, `FermionOpEntry`) from the parsed components, avoiding the
+/// need for a shared trait on the entry types in `quspin-core`.
+pub(crate) fn parse_terms_generic<C, Op, E, F>(
+    py: Python<'_>,
+    terms: &[Term],
+    make_entry: F,
+) -> Result<Vec<E>, quspin_core::error::QuSpinError>
+where
+    C: Copy + Ord + TryFrom<usize>,
+    <C as TryFrom<usize>>::Error: std::fmt::Debug,
+    Op: ParseOp,
+    F: Fn(C, Complex<f64>, SmallVec<[(Op, u32); 4]>) -> E,
+{
+    let mut entries = Vec::new();
+    for (cindex_usize, term) in terms.iter().enumerate() {
+        let cindex = C::try_from(cindex_usize).map_err(|_| {
+            quspin_core::error::QuSpinError::ValueError(format!(
+                "cindex {cindex_usize} out of range for chosen index type"
+            ))
+        })?;
+        for (op_str, bonds) in term {
+            for bond in bonds {
+                if bond.is_empty() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(
+                        "each bond must be [coeff, site0, site1, ...]".to_string(),
+                    ));
+                }
+                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
+                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
+                })?;
+                let sites: Vec<u32> = bond[1..]
+                    .iter()
+                    .map(|s| {
+                        s.bind(py).extract::<u32>().map_err(|e| {
+                            quspin_core::error::QuSpinError::ValueError(format!(
+                                "bond site index: {e}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                if op_str.len() != sites.len() {
+                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
+                        "op_str length {} != number of sites {}",
+                        op_str.len(),
+                        sites.len()
+                    )));
+                }
+                let mut ops: SmallVec<[(Op, u32); 4]> = SmallVec::new();
+                for (ch, &site) in op_str.chars().zip(sites.iter()) {
+                    let op = Op::from_char(ch)?;
+                    ops.push((op, site));
+                }
+                entries.push(make_entry(cindex, coeff, ops));
+            }
+        }
+    }
+    Ok(entries)
 }

--- a/crates/quspin-py/src/operator/pauli.rs
+++ b/crates/quspin-py/src/operator/pauli.rs
@@ -1,15 +1,11 @@
 use crate::error::Error;
-use crate::operator::{as_c64_vec, with_space_inner, with_two_space_inners, write_c64_back};
-use num_complex::Complex;
+use crate::operator::{
+    Terms, as_c64_vec, max_site_from_terms, parse_terms_generic, with_space_inner,
+    with_two_space_inners, write_c64_back,
+};
 use numpy::{Complex64, PyArray1};
 use pyo3::prelude::*;
 use quspin_core::operator::pauli::{HardcoreOp, HardcoreOperator, HardcoreOperatorInner, OpEntry};
-use smallvec::SmallVec;
-
-/// A single term: a list of `(op_str, bonds)` pairs sharing one cindex.
-pub(crate) type Term = Vec<(String, Vec<Vec<PyObject>>)>;
-/// All terms passed to a constructor (one per cindex).
-pub(crate) type Terms = Vec<Term>;
 
 /// Python-facing Pauli / hardcore-boson / spin-½ operator.
 ///
@@ -46,12 +42,14 @@ impl PyPauliOperator {
         let use_u8 = max_cindex <= 255 && max_site <= 255;
 
         if use_u8 {
-            let entries = parse_terms::<u8>(py, &terms).map_err(Error::from)?;
+            let entries = parse_terms_generic::<u8, HardcoreOp, _, _>(py, &terms, OpEntry::new)
+                .map_err(Error::from)?;
             Ok(PyPauliOperator {
                 inner: HardcoreOperatorInner::Ham8(HardcoreOperator::new(entries)),
             })
         } else if max_cindex <= 65535 && max_site <= 65535 {
-            let entries = parse_terms::<u16>(py, &terms).map_err(Error::from)?;
+            let entries = parse_terms_generic::<u16, HardcoreOp, _, _>(py, &terms, OpEntry::new)
+                .map_err(Error::from)?;
             Ok(PyPauliOperator {
                 inner: HardcoreOperatorInner::Ham16(HardcoreOperator::new(entries)),
             })
@@ -141,92 +139,4 @@ impl PyPauliOperator {
             self.inner.num_cindices(),
         )
     }
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-/// Extract the max site index from all bonds across all terms.
-pub(crate) fn max_site_from_terms(py: Python<'_>, terms: &[Term]) -> PyResult<usize> {
-    let mut max = 0usize;
-    for term in terms {
-        for (_, bonds) in term {
-            for bond in bonds {
-                // bond = [coeff, site0, site1, ...]  — skip index 0 (coeff)
-                for obj in bond.iter().skip(1) {
-                    let site: u32 = obj.bind(py).extract()?;
-                    max = max.max(site as usize);
-                }
-            }
-        }
-    }
-    Ok(max)
-}
-
-/// Extract a complex coefficient from a Python scalar (int, float, or complex).
-pub(crate) fn extract_coeff(py: Python<'_>, obj: &PyObject) -> PyResult<Complex<f64>> {
-    let bound = obj.bind(py);
-    if let Ok(z) = bound.extract::<Complex<f64>>() {
-        return Ok(z);
-    }
-    let re: f64 = bound.extract()?;
-    Ok(Complex::new(re, 0.0))
-}
-
-fn parse_terms<C: Copy + Ord + TryFrom<usize>>(
-    py: Python<'_>,
-    terms: &[Term],
-) -> Result<Vec<OpEntry<C>>, quspin_core::error::QuSpinError>
-where
-    <C as TryFrom<usize>>::Error: std::fmt::Debug,
-{
-    let mut entries = Vec::new();
-    for (cindex_usize, term) in terms.iter().enumerate() {
-        let cindex = C::try_from(cindex_usize).map_err(|_| {
-            quspin_core::error::QuSpinError::ValueError(format!(
-                "cindex {cindex_usize} out of range for chosen index type"
-            ))
-        })?;
-        for (op_str, bonds) in term {
-            for bond in bonds {
-                if bond.is_empty() {
-                    return Err(quspin_core::error::QuSpinError::ValueError(
-                        "each bond must be [coeff, site0, site1, ...]".to_string(),
-                    ));
-                }
-                let coeff = extract_coeff(py, &bond[0]).map_err(|e| {
-                    quspin_core::error::QuSpinError::ValueError(format!("bond coefficient: {e}"))
-                })?;
-                let sites: Vec<u32> = bond[1..]
-                    .iter()
-                    .map(|s| {
-                        s.bind(py).extract::<u32>().map_err(|e| {
-                            quspin_core::error::QuSpinError::ValueError(format!(
-                                "bond site index: {e}"
-                            ))
-                        })
-                    })
-                    .collect::<Result<_, _>>()?;
-                if op_str.len() != sites.len() {
-                    return Err(quspin_core::error::QuSpinError::ValueError(format!(
-                        "op_str length {} != number of sites {}",
-                        op_str.len(),
-                        sites.len()
-                    )));
-                }
-                let mut ops: SmallVec<[(HardcoreOp, u32); 4]> = SmallVec::new();
-                for (ch, &site) in op_str.chars().zip(sites.iter()) {
-                    let op = HardcoreOp::from_char(ch).ok_or_else(|| {
-                        quspin_core::error::QuSpinError::ValueError(format!(
-                            "unknown operator character '{ch}'; expected one of x, y, z, +, -, n"
-                        ))
-                    })?;
-                    ops.push((op, site));
-                }
-                entries.push(OpEntry::new(cindex, coeff, ops));
-            }
-        }
-    }
-    Ok(entries)
 }


### PR DESCRIPTION
## Summary

- Extracted shared `Term`/`Terms` type aliases, `max_site_from_terms()`, and `extract_coeff()` from `pauli.rs` into `operator/mod.rs`
- Introduced a generic `parse_terms_generic<C, Op, E, F>()` function that works for any operator type implementing `ParseOp`, parameterized by a constructor closure to build the concrete entry type (`OpEntry`, `BosonOpEntry`, `FermionOpEntry`)
- Removed ~150 lines of near-identical `parse_terms` code from `pauli.rs`, `boson.rs`, and `fermion.rs`

Closes #29

## Test plan

- [x] `cargo check -p quspin-py` compiles cleanly
- [x] `cargo clippy -p quspin-core -p quspin-py --all-targets -- -D warnings` passes
- [x] `cargo test -p quspin-core` -- all 275 tests pass
- [x] All pre-commit hooks pass (fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)