### PR TITLE
perf: parallelize basis ops and fuse BFS+orbit in SymBasis::build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Install Python dependencies
         run: uv sync --group dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C debuginfo=0"
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/quspin-core/src/basis/expand.rs
+++ b/crates/quspin-core/src/basis/expand.rs
@@ -24,8 +24,13 @@ use super::{
 use crate::bitbasis::{BenesPermDitLocations, BitInt, BitStateOp, manip::DynamicDitManip};
 use ndarray::{Array2, ArrayBase, ArrayView1, Data, Ix1, aview1};
 use num_complex::Complex;
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::ops::AddAssign;
+
+/// Minimum number of basis states before switching `expand_to_map` to the
+/// parallel fold/reduce path.
+const PARALLEL_EXPAND_THRESHOLD: usize = 256;
 
 // ---------------------------------------------------------------------------
 // AsStateVec — blanket conversion to ArrayView1
@@ -92,17 +97,42 @@ pub fn expand_to_map<B, T, E, V>(space: &E, vec: &V) -> HashMap<B, Complex<f64>>
 where
     B: BitInt,
     V: ToView<T> + ?Sized,
-    E: BasisSpace<B> + ExpandRefState<B, T, Complex<f64>>,
+    T: Sync,
+    E: BasisSpace<B> + ExpandRefState<B, T, Complex<f64>> + Sync,
 {
     let vec = vec.to_view();
     debug_assert_eq!(vec.len(), space.size());
-    let mut map: HashMap<B, Complex<f64>> = HashMap::new();
-    for (i, coeff) in vec.iter().enumerate() {
-        for (state, val) in space.expand_ref_state_iter(i, coeff) {
-            *map.entry(state).or_insert(Complex::new(0.0, 0.0)) += val;
+
+    if vec.len() < PARALLEL_EXPAND_THRESHOLD {
+        let mut map: HashMap<B, Complex<f64>> = HashMap::new();
+        for (i, coeff) in vec.iter().enumerate() {
+            for (state, val) in space.expand_ref_state_iter(i, coeff) {
+                *map.entry(state).or_insert(Complex::new(0.0, 0.0)) += val;
+            }
         }
+        map
+    } else {
+        (0..vec.len())
+            .into_par_iter()
+            .fold(
+                || HashMap::<B, Complex<f64>>::new(),
+                |mut local_map, i| {
+                    for (state, val) in space.expand_ref_state_iter(i, &vec[i]) {
+                        *local_map.entry(state).or_insert(Complex::new(0.0, 0.0)) += val;
+                    }
+                    local_map
+                },
+            )
+            .reduce(
+                || HashMap::new(),
+                |mut a, b| {
+                    for (k, v) in b {
+                        *a.entry(k).or_insert(Complex::new(0.0, 0.0)) += v;
+                    }
+                    a
+                },
+            )
     }
-    map
 }
 
 // ---------------------------------------------------------------------------
@@ -127,7 +157,8 @@ pub fn get_full_vector<B, T, E, FS, V>(
 ) where
     B: BitInt,
     V: ToView<T> + ?Sized,
-    E: BasisSpace<B> + ExpandRefState<B, T, Complex<f64>>,
+    T: Sync,
+    E: BasisSpace<B> + ExpandRefState<B, T, Complex<f64>> + Sync,
     FS: BasisSpace<B>,
     Complex<f64>: AddAssign,
 {
@@ -195,7 +226,8 @@ pub fn reduced_density_matrix<B, T, E, V>(
 ) where
     B: BitInt,
     V: ToView<T> + ?Sized,
-    E: BasisSpace<B> + ExpandRefState<B, T, Complex<f64>>,
+    T: Sync,
+    E: BasisSpace<B> + ExpandRefState<B, T, Complex<f64>> + Sync,
 {
     let vec = vec.to_view();
     debug_assert_eq!(vec.len(), space.size());
@@ -262,13 +294,30 @@ pub fn reduced_density_matrix<B, T, E, V>(
     }
 
     // Step 3: accumulate outer products into the RDM.
-    for group in groups.values() {
-        for &(sa_i, c_i) in group {
-            for &(sa_j, c_j) in group {
-                out[[sa_i, sa_j]] += c_i * c_j.conj();
-            }
-        }
-    }
+    // Each group is independent (different s_B), so parallelise over groups with
+    // thread-local accumulators to avoid write conflicts on `out`.
+    let groups_vec: Vec<_> = groups.values().collect();
+    let combined: Array2<Complex<f64>> = groups_vec
+        .par_iter()
+        .fold(
+            || Array2::<Complex<f64>>::zeros((dim_a, dim_a)),
+            |mut local, group| {
+                for &(sa_i, c_i) in group.iter() {
+                    for &(sa_j, c_j) in group.iter() {
+                        local[[sa_i, sa_j]] += c_i * c_j.conj();
+                    }
+                }
+                local
+            },
+        )
+        .reduce(
+            || Array2::<Complex<f64>>::zeros((dim_a, dim_a)),
+            |mut a, b| {
+                a += &b;
+                a
+            },
+        );
+    *out += &combined;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/quspin-core/src/basis/sym.rs
+++ b/crates/quspin-core/src/basis/sym.rs
@@ -3,7 +3,7 @@
 /// Replaces the two-type hierarchy (`SymGrpBase<B,L>` + `SymmetricSubspace<G,N>`)
 /// with a single flat struct. `N` is an explicit type parameter — the B→N
 /// pairing is encoded in `SpaceInner` variant definitions, not a runtime enum.
-use super::bfs::bfs_wave;
+use super::bfs::{AMP_CANCEL_TOL, PARALLEL_FRONTIER_THRESHOLD};
 use super::lattice::{BenesLatticeElement, LatEl, LocalOpItem};
 use super::traits::BasisSpace;
 use crate::bitbasis::{BenesPermDitLocations, BitInt, BitStateOp};
@@ -210,10 +210,19 @@ impl<B: BitInt, L: BitStateOp<B>, N: NormInt> SymBasis<B, L, N> {
 
     /// Build the symmetric subspace reachable from `seed` under `op`.
     ///
-    /// Uses level-synchronous BFS with three phases per wave:
-    /// 1. Parallel operator application over the frontier
-    /// 2. Parallel batch orbit computation (deferred, one large batch)
-    /// 3. Sequential registration of new representative states
+    /// Uses level-synchronous BFS with two parallel phases per wave:
+    ///
+    /// 1. **Fused BFS + orbit mapping** — amplitude-cancellation BFS and
+    ///    `get_refstate` per surviving candidate run in one parallel fold/reduce,
+    ///    yielding a `HashSet<B>` of orbit representatives directly.
+    ///    This replaces the former separate BFS pass and the subsequent
+    ///    `check_refstate_batch` on every candidate (which computed norms that
+    ///    were immediately discarded).
+    /// 2. **Parallel norm computation** — `par_check_refstate_batch` on the
+    ///    unique new representatives only (the smallest possible batch),
+    ///    retaining the SIMD-friendly batch orbit traversal for this step.
+    /// 3. **Sequential registration** — dedup and index-map update on the main
+    ///    thread; frontier for the next wave assembled here.
     pub fn build<Op, I, Iter>(&mut self, seed: B, op: Op)
     where
         Op: Fn(B) -> Iter + Sync,
@@ -234,27 +243,21 @@ impl<B: BitInt, L: BitStateOp<B>, N: NormInt> SymBasis<B, L, N> {
         let mut frontier: Vec<B> = vec![ref_seed];
 
         while !frontier.is_empty() {
-            // Phase 1: discover raw candidate states via operator application.
-            // Per-source amplitude accumulation and cancellation, then union.
-            let candidates: Vec<B> = bfs_wave(&frontier, &op).into_iter().collect();
+            let lattice = &self.lattice;
+            let local = &self.local;
 
-            if candidates.is_empty() {
+            // Phase 1+2a (fused): BFS discovery + orbit-representative mapping
+            // in a single parallel fold — one fork/join instead of two.
+            // Uses get_refstate (no norm computation) per surviving candidate.
+            let candidate_reps: HashSet<B> = bfs_wave_with_reps(&frontier, &op, lattice, local);
+
+            if candidate_reps.is_empty() {
                 frontier.clear();
                 continue;
             }
 
-            // Phase 2a: map candidates to their orbit representatives.
-            let lattice = &self.lattice;
-            let local = &self.local;
-
-            let mut ref_out: Vec<(B, f64)> = vec![(B::from_u64(0), 0.0); candidates.len()];
-            par_check_refstate_batch(lattice, local, &candidates, &mut ref_out);
-
-            // Collect unique new representatives (not already in index_map).
-            let unique_reps: Vec<B> = ref_out
-                .iter()
-                .map(|(rep, _)| *rep)
-                .collect::<HashSet<B>>()
+            // Sequential dedup: keep only reps not already registered.
+            let unique_reps: Vec<B> = candidate_reps
                 .into_iter()
                 .filter(|rep| !self.index_map.contains_key(rep))
                 .collect();
@@ -264,11 +267,12 @@ impl<B: BitInt, L: BitStateOp<B>, N: NormInt> SymBasis<B, L, N> {
                 continue;
             }
 
-            // Phase 2b: compute orbit norms for unique representatives.
+            // Phase 2b: compute orbit norms for unique new representatives.
+            // Batch call retains SIMD-friendly inner-loop structure.
             let mut norm_out: Vec<(B, f64)> = vec![(B::from_u64(0), 0.0); unique_reps.len()];
             par_check_refstate_batch(lattice, local, &unique_reps, &mut norm_out);
 
-            // Phase 3: register new representatives and form next frontier.
+            // Phase 3: register valid representatives, build next frontier.
             frontier.clear();
             for (&rep, &(_, norm)) in unique_reps.iter().zip(norm_out.iter()) {
                 if norm > 0.0
@@ -290,6 +294,103 @@ impl<B: BitInt, L: BitStateOp<B>, N: NormInt> SymBasis<B, L, N> {
         for (i, &(s, _)) in self.states.iter().enumerate() {
             self.index_map.insert(s, i);
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fused BFS + orbit-representative helper
+// ---------------------------------------------------------------------------
+
+/// Fused BFS wave + orbit-representative mapping.
+///
+/// Combines amplitude-cancellation BFS discovery (the work previously done by
+/// `bfs_wave`) with a per-candidate [`orbit::get_refstate`] call in a single
+/// parallel fold/reduce.  This eliminates the separate
+/// `par_check_refstate_batch` pass on every raw candidate that the old code
+/// performed (which computed norms that were immediately discarded during
+/// deduplication).
+///
+/// ## Returns
+///
+/// A [`HashSet<B>`] of orbit-representative states reached from `frontier` in
+/// one BFS wave.  Representatives are already de-duplicated; the caller is
+/// responsible for filtering out those already in `index_map`.
+///
+/// ## Parallelism
+///
+/// - Below [`PARALLEL_FRONTIER_THRESHOLD`]: sequential single-threaded path.
+/// - Above threshold: rayon `par_iter().fold().reduce()` — each thread owns a
+///   disjoint slice of `frontier`, builds a thread-local `HashSet<B>` of
+///   representatives, and the sets are unioned in the reduce step.
+fn bfs_wave_with_reps<B, E, L, Op, I, Iter>(
+    frontier: &[B],
+    op: &Op,
+    lattice: &[E],
+    local: &[L],
+) -> HashSet<B>
+where
+    B: BitInt,
+    E: LatEl<B> + Sync,
+    L: LocalOpItem<B> + Sync,
+    Op: Fn(B) -> Iter + Sync,
+    Iter: IntoIterator<Item = (Complex<f64>, B, I)>,
+{
+    if frontier.len() < PARALLEL_FRONTIER_THRESHOLD {
+        let mut reps = HashSet::new();
+        let mut contributions: HashMap<B, (Complex<f64>, f64)> = HashMap::new();
+        for &state in frontier {
+            contributions.clear();
+            for (amp, next_state, _) in op(state) {
+                if next_state != state {
+                    let e = contributions.entry(next_state).or_default();
+                    e.0 += amp;
+                    e.1 += amp.norm();
+                }
+            }
+            for (&candidate, &(net_amp, scale)) in &contributions {
+                if net_amp.norm() > scale * AMP_CANCEL_TOL {
+                    let (rep, _) = super::orbit::get_refstate(lattice, local, candidate);
+                    reps.insert(rep);
+                }
+            }
+        }
+        reps
+    } else {
+        frontier
+            .par_iter()
+            .fold(
+                || {
+                    (
+                        HashSet::<B>::new(),
+                        HashMap::<B, (Complex<f64>, f64)>::new(),
+                    )
+                },
+                |(mut reps, mut contributions), &state| {
+                    contributions.clear();
+                    for (amp, next_state, _) in op(state) {
+                        if next_state != state {
+                            let e = contributions.entry(next_state).or_default();
+                            e.0 += amp;
+                            e.1 += amp.norm();
+                        }
+                    }
+                    for (&candidate, &(net_amp, scale)) in &contributions {
+                        if net_amp.norm() > scale * AMP_CANCEL_TOL {
+                            let (rep, _) = super::orbit::get_refstate(lattice, local, candidate);
+                            reps.insert(rep);
+                        }
+                    }
+                    (reps, contributions)
+                },
+            )
+            .map(|(reps, _)| reps)
+            .reduce(
+                || HashSet::new(),
+                |mut a, b| {
+                    a.extend(b);
+                    a
+                },
+            )
     }
 }
 

--- a/crates/quspin-core/src/operator/apply.rs
+++ b/crates/quspin-core/src/operator/apply.rs
@@ -7,8 +7,12 @@ use crate::bitbasis::{BitInt, BitStateOp};
 use crate::error::QuSpinError;
 use crate::qmatrix::CIndex;
 use num_complex::Complex;
+use rayon::prelude::*;
 
 type C64 = Complex<f64>;
+
+/// Minimum input-space size before switching to parallel application.
+const PARALLEL_APPLY_THRESHOLD: usize = 256;
 
 // ---------------------------------------------------------------------------
 // ProjectState — zero-cost abstraction over output projection
@@ -77,11 +81,11 @@ pub fn apply_and_project_to_inner<H, B, C, IS, OS>(
     overwrite: bool,
 ) -> Result<(), QuSpinError>
 where
-    H: Operator<C>,
+    H: Operator<C> + Sync,
     B: BitInt,
     C: CIndex,
-    IS: BasisSpace<B> + ExpandRefState<B, C64, C64>,
-    OS: ProjectState<B>,
+    IS: BasisSpace<B> + ExpandRefState<B, C64, C64> + Sync,
+    OS: ProjectState<B> + Sync,
 {
     validate_args(
         op.num_cindices(),
@@ -100,16 +104,51 @@ where
         output.iter_mut().for_each(|c| *c = C64::default());
     }
 
-    for (i, coeff) in input.iter().enumerate() {
-        for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
-            if amp.norm_sqr() == 0.0 {
-                continue;
-            }
-            op.apply(state, |cindex, op_amp, new_state| {
-                if let Some((j, scale)) = output_space.project(new_state) {
-                    output[j] += coeffs[cindex.as_usize()] * op_amp * amp * scale;
+    if input.len() < PARALLEL_APPLY_THRESHOLD {
+        for (i, coeff) in input.iter().enumerate() {
+            for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
+                if amp.norm_sqr() == 0.0 {
+                    continue;
                 }
-            });
+                op.apply(state, |cindex, op_amp, new_state| {
+                    if let Some((j, scale)) = output_space.project(new_state) {
+                        output[j] += coeffs[cindex.as_usize()] * op_amp * amp * scale;
+                    }
+                });
+            }
+        }
+    } else {
+        let output_size = output_space.size();
+        let combined: Vec<C64> = input
+            .par_iter()
+            .enumerate()
+            .fold(
+                || vec![C64::default(); output_size],
+                |mut local_out, (i, coeff)| {
+                    for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
+                        if amp.norm_sqr() == 0.0 {
+                            continue;
+                        }
+                        op.apply(state, |cindex, op_amp, new_state| {
+                            if let Some((j, scale)) = output_space.project(new_state) {
+                                local_out[j] += coeffs[cindex.as_usize()] * op_amp * amp * scale;
+                            }
+                        });
+                    }
+                    local_out
+                },
+            )
+            .reduce(
+                || vec![C64::default(); output_size],
+                |mut a, b| {
+                    for (x, y) in a.iter_mut().zip(b.iter()) {
+                        *x += y;
+                    }
+                    a
+                },
+            );
+        for (o, c) in output.iter_mut().zip(combined.iter()) {
+            *o += c;
         }
     }
 
@@ -135,8 +174,8 @@ pub fn project_to_inner<B, IS, OS>(
 ) -> Result<(), QuSpinError>
 where
     B: BitInt,
-    IS: BasisSpace<B> + ExpandRefState<B, C64, C64>,
-    OS: ProjectState<B>,
+    IS: BasisSpace<B> + ExpandRefState<B, C64, C64> + Sync,
+    OS: ProjectState<B> + Sync,
 {
     if input_space.n_sites() != output_space.n_sites() {
         return Err(QuSpinError::ValueError(format!(
@@ -171,14 +210,47 @@ where
         output.iter_mut().for_each(|c| *c = C64::default());
     }
 
-    for (i, coeff) in input.iter().enumerate() {
-        for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
-            if amp.norm_sqr() == 0.0 {
-                continue;
+    if input.len() < PARALLEL_APPLY_THRESHOLD {
+        for (i, coeff) in input.iter().enumerate() {
+            for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
+                if amp.norm_sqr() == 0.0 {
+                    continue;
+                }
+                if let Some((j, scale)) = output_space.project(state) {
+                    output[j] += amp * scale;
+                }
             }
-            if let Some((j, scale)) = output_space.project(state) {
-                output[j] += amp * scale;
-            }
+        }
+    } else {
+        let output_size = output_space.size();
+        let combined: Vec<C64> = input
+            .par_iter()
+            .enumerate()
+            .fold(
+                || vec![C64::default(); output_size],
+                |mut local_out, (i, coeff)| {
+                    for (state, amp) in input_space.expand_ref_state_iter(i, coeff) {
+                        if amp.norm_sqr() == 0.0 {
+                            continue;
+                        }
+                        if let Some((j, scale)) = output_space.project(state) {
+                            local_out[j] += amp * scale;
+                        }
+                    }
+                    local_out
+                },
+            )
+            .reduce(
+                || vec![C64::default(); output_size],
+                |mut a, b| {
+                    for (x, y) in a.iter_mut().zip(b.iter()) {
+                        *x += y;
+                    }
+                    a
+                },
+            );
+        for (o, c) in output.iter_mut().zip(combined.iter()) {
+            *o += c;
         }
     }
 
@@ -305,7 +377,7 @@ pub fn apply_and_project_to<H, C>(
     overwrite: bool,
 ) -> Result<(), QuSpinError>
 where
-    H: Operator<C>,
+    H: Operator<C> + Sync,
     C: CIndex,
 {
     #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

- **Parallelize `expand_to_map`** (`expand.rs`): rayon `fold`/`reduce` above threshold=256; each thread builds a thread-local `HashMap<B, C64>`, merged at join. Adds `E: Sync + T: Sync` bounds propagated to `get_full_vector` and `reduced_density_matrix`.
- **Parallelize RDM group accumulation** (`expand.rs`): `par_iter` over B-subsystem groups with thread-local `Array2` accumulators, eliminating write conflicts on the output matrix.
- **Parallelize `apply_and_project_to_inner` / `project_to_inner`** (`apply.rs`): thread-local `Vec<C64>` output buffers via `fold`/`reduce` above threshold=256; adds `H/IS/OS: Sync` bounds propagated to the top-level dispatch.
- **Fuse BFS + orbit mapping in `SymBasis::build`** (`sym.rs`): replaces the three-fork/join-per-wave pattern with two. The old separate `bfs_wave` + `check_refstate_batch` on all candidates (which computed norms that were immediately discarded) is replaced by a single `bfs_wave_with_reps` fold that calls `get_refstate` (cheaper — no norm computation) per surviving candidate. Norms are computed only for the unique new representatives that actually need them, in a single `par_check_refstate_batch` call.

Closes #34, closes #35.

## Test plan

- [x] `cargo test -p quspin-core` — 279 tests pass
- [x] `cargo clippy -p quspin-core -p quspin-py --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)