### PR TITLE
build(quspin-py): make large-int opt-in to speed up CI / dev builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,16 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace -- -D warnings
 
+      # Default builds skip `large-int` so CI / dev iteration aren't paying
+      # for the wide-integer (Uint<512..8192>) monomorphizations. Run a
+      # type-check pass with the feature on so the gated paths don't
+      # bit-rot.
+      - name: cargo check (large-int)
+        run: cargo check --workspace --features quspin-py/large-int
+
+      - name: cargo clippy (large-int)
+        run: cargo clippy --workspace --features quspin-py/large-int -- -D warnings
+
       # Enforces the basis/operator DAG invariant that the StateTransitions
       # refactor was designed to achieve. A plain `cargo build` does NOT
       # catch someone reintroducing `quspin-operator` to quspin-basis's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,6 @@ GitHub Actions (`.github/workflows/ci.yaml`): `Swatinem/rust-cache` warms `targe
 - **Error handling:** `Result<T, QuSpinError>` in the physics crates; maps to Python exceptions via PyO3
 - **Python package:** `quspin-rs`, module `quspin_rs._rs`, built with maturin against `quspin-py`
 - **Type stubs:** `python/quspin_rs/_rs.pyi`
-- **`large-int` feature:** gates `Uint<512..8192>` variants; declared on `quspin-bitbasis`, `quspin-basis`, `quspin-matrix`, and `quspin-core` (which forwards through the chain)
+- **`large-int` feature:** gates `Uint<512..8192>` variants; declared on `quspin-bitbasis`, `quspin-basis`, `quspin-matrix`, and `quspin-core` (which forwards through the chain). `quspin-py` re-exposes it as its own feature, off by default — `cargo build` / `maturin develop` skip the wide-integer monomorphizations for faster dev iteration. Enable explicitly with `cargo build --features quspin-py/large-int` or `maturin develop --features large-int`. CI runs a separate `cargo check`/`clippy` pass with the feature on so the gated paths don't bit-rot.
 
 See `docs/` for detailed design documents, including `docs/superpowers/specs/2026-04-18-crate-split-design.md` for the crate-split rationale.

--- a/crates/quspin-py/Cargo.toml
+++ b/crates/quspin-py/Cargo.toml
@@ -7,8 +7,17 @@ edition.workspace = true
 name = "_rs"
 crate-type = ["cdylib"]
 
+[features]
+# Forwards `large-int` through quspin-core, gating the wide-integer
+# (Uint<512..8192>) variants of every dispatch enum. Off by default so
+# `cargo build` / `maturin develop` skip the heavy monomorphizations
+# during day-to-day development; enable explicitly for release wheels
+# or when needed via `cargo build --features large-int` /
+# `maturin develop --features large-int`.
+large-int = ["quspin-core/large-int"]
+
 [dependencies]
-quspin-core = { path = "../quspin-core", features = ["large-int"] }
+quspin-core = { path = "../quspin-core" }
 num-complex = { workspace = true }
 ndarray = { workspace = true }
 ruint = { workspace = true }


### PR DESCRIPTION
Closes #60.

## Summary

- `quspin-py` was hardcoding `features = ["large-int"]` on its `quspin-core` dependency, so every default `cargo build` / `cargo test` / `maturin develop` was paying for the wide-integer (`Uint<512..8192>`) monomorphizations of every dispatch enum.
- Drop the hardcoded feature on the dependency line and re-expose `large-int` as a feature on `quspin-py` itself (off by default).
- Add a CI step that runs `cargo check` + `cargo clippy` with `--features quspin-py/large-int` so the gated paths still get a type-check / lint pass and don't bit-rot.
- Document the new flag in `CLAUDE.md`.

## Local timing

`maturin develop` (clean target/): **3m 08s → 1m 33s** on my machine.

## Test plan

- [x] `cargo check --workspace` (default, no large-int)
- [x] `cargo check --workspace --features quspin-py/large-int`
- [x] `cargo test --workspace` (default) — all 113 Rust unit tests pass
- [x] `just develop` + `just test-python-fast` — all 113 Python tests pass
- [x] CI green on push (incl. the new `cargo check (large-int)` / `cargo clippy (large-int)` steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)