### PR TITLE
feat(quspin-py): SciPy LinearOperator interface on QMatrixLinearOperator (closes #108)

### DIFF
--- a/crates/quspin-py/src/linear_operator.rs
+++ b/crates/quspin-py/src/linear_operator.rs
@@ -1,8 +1,16 @@
 use std::sync::Arc;
 
+use ndarray::Array2;
 use num_complex::Complex;
+use numpy::{
+    Complex64, PyArray1, PyArray2, PyArrayDescr, PyArrayMethods, PyReadonlyArray1,
+    PyReadonlyArray2, PyUntypedArrayMethods,
+};
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use quspin_core::OwnedQMatrixOperator;
+use quspin_core::{LinearOperator, OwnedQMatrixOperator};
+
+use crate::error::Error;
 
 /// Python-facing snapshot of a `QMatrix` + coefficient vector — i.e. a
 /// concrete `LinearOperator<Complex<f64>>`.
@@ -12,6 +20,10 @@ use quspin_core::OwnedQMatrixOperator;
 /// Constructed via `QMatrix.as_linearoperator(coeffs)` or
 /// `Hamiltonian.as_linearoperator(time)`; not constructible from Python
 /// directly.
+///
+/// Exposes the SciPy `LinearOperator` duck-typed interface (`shape`,
+/// `dtype`, `matvec`, `matmat`, `rmatvec`, `rmatmat`, `@`) so instances can
+/// be passed directly to `scipy.sparse.linalg` routines.
 #[pyclass(name = "QMatrixLinearOperator", module = "quspin_rs._rs", frozen)]
 pub struct PyQMatrixLinearOperator {
     pub inner: Arc<OwnedQMatrixOperator<Complex<f64>>>,
@@ -19,6 +31,13 @@ pub struct PyQMatrixLinearOperator {
 
 #[pymethods]
 impl PyQMatrixLinearOperator {
+    /// Opt out of numpy ufuncs so `np.ndarray @ qop` defers to our
+    /// `__rmatmul__` instead of numpy attempting an elementwise op.
+    #[classattr]
+    fn __array_ufunc__(py: Python<'_>) -> Py<PyAny> {
+        py.None()
+    }
+
     #[getter]
     fn dim(&self) -> usize {
         self.inner.matrix().dim()
@@ -29,17 +48,241 @@ impl PyQMatrixLinearOperator {
         self.inner.matrix().num_coeff()
     }
 
+    /// SciPy-compatible ``(dim, dim)`` shape tuple.
     #[getter]
-    fn dtype(&self) -> &str {
-        self.inner.matrix().dtype_name()
+    fn shape(&self) -> (usize, usize) {
+        let n = self.inner.matrix().dim();
+        (n, n)
+    }
+
+    /// SciPy-compatible ``numpy.dtype``.  Always ``complex128`` — matvec is
+    /// run in complex128 regardless of the matrix's storage dtype because
+    /// `as_linearoperator` accepts complex coefficients.
+    #[getter]
+    fn dtype<'py>(&self, py: Python<'py>) -> Bound<'py, PyArrayDescr> {
+        numpy::dtype::<Complex64>(py)
+    }
+
+    /// ``A @ x`` for a 1-D complex128 input.
+    fn matvec<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyReadonlyArray1<'py, Complex64>,
+    ) -> PyResult<Bound<'py, PyArray1<Complex64>>> {
+        let n = self.inner.matrix().dim();
+        if x.len() != n {
+            return Err(PyValueError::new_err(format!(
+                "x must have length {n}, got {}",
+                x.len(),
+            )));
+        }
+        let in_slice = x
+            .as_slice()
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let out = PyArray1::<Complex64>::zeros(py, [n], false);
+        {
+            let mut rw = out.try_readwrite()?;
+            let mut view = rw.as_array_mut();
+            let out_slice = view
+                .as_slice_mut()
+                .expect("freshly-allocated PyArray1 is contiguous");
+            py.detach(|| self.inner.dot(true, in_slice, out_slice))
+                .map_err(Error::from)?;
+        }
+        Ok(out)
+    }
+
+    /// ``A @ X`` for a 2-D complex128 input of shape ``(dim, k)``.
+    fn matmat<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyReadonlyArray2<'py, Complex64>,
+    ) -> PyResult<Bound<'py, PyArray2<Complex64>>> {
+        let n = self.inner.matrix().dim();
+        let shape = x.shape();
+        if shape[0] != n {
+            return Err(PyValueError::new_err(format!(
+                "x.shape[0] must be {n}, got {}",
+                shape[0],
+            )));
+        }
+        let k = shape[1];
+        let in_view = x.as_array();
+        let out = PyArray2::<Complex64>::zeros(py, [n, k], false);
+        {
+            let mut rw = out.try_readwrite()?;
+            let out_view = rw.as_array_mut();
+            py.detach(|| self.inner.dot_many(true, in_view, out_view))
+                .map_err(Error::from)?;
+        }
+        Ok(out)
+    }
+
+    /// ``A^H @ x`` for a 1-D input — SciPy `rmatvec`.  Computed as
+    /// ``conj(A^T @ conj(x))`` so it matches the Hermitian adjoint even when
+    /// the underlying matrix has complex entries.
+    fn rmatvec<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyReadonlyArray1<'py, Complex64>,
+    ) -> PyResult<Bound<'py, PyArray1<Complex64>>> {
+        let n = self.inner.matrix().dim();
+        if x.len() != n {
+            return Err(PyValueError::new_err(format!(
+                "x must have length {n}, got {}",
+                x.len(),
+            )));
+        }
+        let in_conj: Vec<Complex<f64>> = x.as_array().iter().map(|c| c.conj()).collect();
+        let out = PyArray1::<Complex64>::zeros(py, [n], false);
+        {
+            let mut rw = out.try_readwrite()?;
+            let mut view = rw.as_array_mut();
+            let out_slice = view
+                .as_slice_mut()
+                .expect("freshly-allocated PyArray1 is contiguous");
+            py.detach(|| self.inner.dot_transpose(true, &in_conj, out_slice))
+                .map_err(Error::from)?;
+            for v in out_slice.iter_mut() {
+                *v = v.conj();
+            }
+        }
+        Ok(out)
+    }
+
+    /// ``A^H @ X`` for a 2-D input of shape ``(dim, k)`` — SciPy `rmatmat`.
+    fn rmatmat<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyReadonlyArray2<'py, Complex64>,
+    ) -> PyResult<Bound<'py, PyArray2<Complex64>>> {
+        let n = self.inner.matrix().dim();
+        let shape = x.shape();
+        if shape[0] != n {
+            return Err(PyValueError::new_err(format!(
+                "x.shape[0] must be {n}, got {}",
+                shape[0],
+            )));
+        }
+        let k = shape[1];
+        let x_arr = x.as_array();
+        let mut in_conj = Array2::<Complex<f64>>::zeros((n, k));
+        for ((r, c), v) in x_arr.indexed_iter() {
+            in_conj[[r, c]] = v.conj();
+        }
+        let out = PyArray2::<Complex64>::zeros(py, [n, k], false);
+        {
+            let mut rw = out.try_readwrite()?;
+            let mut view = rw.as_array_mut();
+            py.detach(|| {
+                self.inner.matrix().dot_transpose_many(
+                    true,
+                    self.inner.coeffs(),
+                    in_conj.view(),
+                    view.view_mut(),
+                )
+            })
+            .map_err(Error::from)?;
+            view.mapv_inplace(|c| c.conj());
+        }
+        Ok(out)
+    }
+
+    /// ``A @ x`` — dispatches to `matvec` (1-D) or `matmat` (2-D).
+    fn __matmul__<'py>(
+        &self,
+        py: Python<'py>,
+        other: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        if let Ok(x) = other.extract::<PyReadonlyArray1<'py, Complex64>>() {
+            return Ok(self.matvec(py, x)?.into_any());
+        }
+        if let Ok(x) = other.extract::<PyReadonlyArray2<'py, Complex64>>() {
+            return Ok(self.matmat(py, x)?.into_any());
+        }
+        Err(PyTypeError::new_err(
+            "QMatrixLinearOperator @ x: x must be a 1-D or 2-D complex128 ndarray",
+        ))
+    }
+
+    /// ``x @ A`` — for a 1-D input returns ``A^T @ x``; for a 2-D ``(m, dim)``
+    /// input returns ``x @ A`` (shape ``(m, dim)``).  Note this is the plain
+    /// transpose (not Hermitian adjoint) to match numpy's ``@`` semantics.
+    fn __rmatmul__<'py>(
+        &self,
+        py: Python<'py>,
+        other: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let n = self.inner.matrix().dim();
+        if let Ok(x) = other.extract::<PyReadonlyArray1<'py, Complex64>>() {
+            if x.len() != n {
+                return Err(PyValueError::new_err(format!(
+                    "x must have length {n}, got {}",
+                    x.len(),
+                )));
+            }
+            let in_slice = x
+                .as_slice()
+                .map_err(|e| PyValueError::new_err(e.to_string()))?;
+            let out = PyArray1::<Complex64>::zeros(py, [n], false);
+            {
+                let mut rw = out.try_readwrite()?;
+                let mut view = rw.as_array_mut();
+                let out_slice = view
+                    .as_slice_mut()
+                    .expect("freshly-allocated PyArray1 is contiguous");
+                py.detach(|| self.inner.dot_transpose(true, in_slice, out_slice))
+                    .map_err(Error::from)?;
+            }
+            return Ok(out.into_any());
+        }
+        if let Ok(x) = other.extract::<PyReadonlyArray2<'py, Complex64>>() {
+            let shape = x.shape();
+            if shape[1] != n {
+                return Err(PyValueError::new_err(format!(
+                    "x.shape[1] must be {n}, got {}",
+                    shape[1],
+                )));
+            }
+            let m = shape[0];
+            // x @ A == (A^T @ x^T)^T.  Build a (n, m) contiguous copy of x^T,
+            // run dot_transpose_many into a (n, m) buffer, then transpose into
+            // the output (m, n).
+            let x_arr = x.as_array();
+            let mut x_t = Array2::<Complex<f64>>::zeros((n, m));
+            for ((i, j), v) in x_arr.indexed_iter() {
+                x_t[[j, i]] = *v;
+            }
+            let mut tmp = Array2::<Complex<f64>>::zeros((n, m));
+            py.detach(|| {
+                self.inner.matrix().dot_transpose_many(
+                    true,
+                    self.inner.coeffs(),
+                    x_t.view(),
+                    tmp.view_mut(),
+                )
+            })
+            .map_err(Error::from)?;
+            let out = PyArray2::<Complex64>::zeros(py, [m, n], false);
+            {
+                let mut rw = out.try_readwrite()?;
+                let mut view = rw.as_array_mut();
+                for ((i, j), v) in tmp.indexed_iter() {
+                    view[[j, i]] = *v;
+                }
+            }
+            return Ok(out.into_any());
+        }
+        Err(PyTypeError::new_err(
+            "x @ QMatrixLinearOperator: x must be a 1-D or 2-D complex128 ndarray",
+        ))
     }
 
     fn __repr__(&self) -> String {
+        let n = self.inner.matrix().dim();
         format!(
-            "QMatrixLinearOperator(dim={}, num_coeff={}, dtype={})",
-            self.inner.matrix().dim(),
+            "QMatrixLinearOperator(shape=({n}, {n}), num_coeff={}, dtype=complex128)",
             self.inner.matrix().num_coeff(),
-            self.inner.matrix().dtype_name(),
         )
     }
 }

--- a/python/quspin_rs/_rs.pyi
+++ b/python/quspin_rs/_rs.pyi
@@ -794,6 +794,11 @@ class QMatrixLinearOperator:
     Construct via ``QMatrix.as_linearoperator(coeffs)`` or
     ``Hamiltonian.as_linearoperator(time)``.  Accepted as the first argument
     to ``ExpmOp``.
+
+    Implements the SciPy ``LinearOperator`` duck-typed interface (``shape``,
+    ``dtype``, ``matvec``, ``matmat``, ``rmatvec``, ``rmatmat``, ``@``) so
+    instances can be passed directly to ``scipy.sparse.linalg`` routines
+    (``eigsh``, ``gmres``, ``expm_multiply``, …).
     """
 
     @property
@@ -801,7 +806,45 @@ class QMatrixLinearOperator:
     @property
     def num_coeff(self) -> int: ...
     @property
-    def dtype(self) -> str: ...
+    def shape(self) -> tuple[int, int]:
+        """``(dim, dim)`` — SciPy ``LinearOperator`` shape."""
+        ...
+
+    @property
+    def dtype(self) -> np.dtype[Any]:
+        """Always ``numpy.dtype('complex128')`` — matvec runs in complex128."""
+        ...
+
+    def matvec(
+        self, x: npt.NDArray[np.complexfloating[Any, Any]]
+    ) -> npt.NDArray[np.complexfloating[Any, Any]]:
+        """Return ``A @ x`` for a 1-D ``complex128`` input."""
+        ...
+
+    def matmat(
+        self, x: npt.NDArray[np.complexfloating[Any, Any]]
+    ) -> npt.NDArray[np.complexfloating[Any, Any]]:
+        """Return ``A @ X`` for a 2-D ``complex128`` input of shape ``(dim, k)``."""
+        ...
+
+    def rmatvec(
+        self, x: npt.NDArray[np.complexfloating[Any, Any]]
+    ) -> npt.NDArray[np.complexfloating[Any, Any]]:
+        """Return ``A^H @ x`` (Hermitian adjoint) for a 1-D ``complex128`` input."""
+        ...
+
+    def rmatmat(
+        self, x: npt.NDArray[np.complexfloating[Any, Any]]
+    ) -> npt.NDArray[np.complexfloating[Any, Any]]:
+        """Return ``A^H @ X`` for a 2-D ``complex128`` input of shape ``(dim, k)``."""
+        ...
+
+    def __matmul__(
+        self, x: npt.NDArray[np.complexfloating[Any, Any]]
+    ) -> npt.NDArray[np.complexfloating[Any, Any]]: ...
+    def __rmatmul__(
+        self, x: npt.NDArray[np.complexfloating[Any, Any]]
+    ) -> npt.NDArray[np.complexfloating[Any, Any]]: ...
     def __repr__(self) -> str: ...
 
 class ExpmOp:

--- a/python/tests/qmatrix/test_linearoperator.py
+++ b/python/tests/qmatrix/test_linearoperator.py
@@ -1,0 +1,133 @@
+"""Tests for the SciPy ``LinearOperator`` duck-typed interface on
+``QMatrixLinearOperator``."""
+
+import numpy as np
+import pytest
+import scipy.sparse.linalg as spla
+
+from quspin_rs._rs import PauliOperator, QMatrix, SpinBasis
+
+N = 4
+
+
+def make_pauli_op() -> PauliOperator:
+    bonds = [[1.0, i, i + 1] for i in range(N - 1)]
+    return PauliOperator([("XX", bonds)], [("ZZ", bonds)])
+
+
+def make_qmatrix() -> QMatrix:
+    return QMatrix.build_pauli(
+        make_pauli_op(), SpinBasis.full(N), np.dtype("complex128")
+    )
+
+
+def dense_from(mat: QMatrix, coeff: np.ndarray) -> np.ndarray:
+    indptr, indices, data = mat.to_csr(coeff)
+    n = mat.dim
+    dense = np.zeros((n, n), dtype=np.complex128)
+    for r in range(n):
+        for k in range(indptr[r], indptr[r + 1]):
+            dense[r, indices[k]] += data[k]
+    return dense
+
+
+class TestQMatrixLinearOperator:
+    def _make(self) -> tuple[QMatrix, np.ndarray, np.ndarray]:
+        mat = make_qmatrix()
+        coeff = np.array([1.0 + 0j, 1.0 + 0j], dtype=np.complex128)
+        return mat, coeff, dense_from(mat, coeff)
+
+    def test_shape_and_dtype(self):
+        mat, coeff, _ = self._make()
+        op = mat.as_linearoperator(coeff)
+        n = mat.dim
+        assert op.shape == (n, n)
+        assert op.dtype == np.dtype("complex128")
+
+    def test_matvec_matches_dense(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        x = np.random.default_rng(0).standard_normal(mat.dim) + 0j
+        y = op.matvec(x)
+        np.testing.assert_allclose(y, dense @ x, atol=1e-12)
+        assert y.dtype == np.complex128
+        assert y.shape == (mat.dim,)
+
+    def test_matmat_matches_dense(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        rng = np.random.default_rng(1)
+        k = 3
+        X = rng.standard_normal((mat.dim, k)) + 1j * rng.standard_normal((mat.dim, k))
+        Y = op.matmat(X)
+        np.testing.assert_allclose(Y, dense @ X, atol=1e-12)
+        assert Y.shape == (mat.dim, k)
+        assert Y.dtype == np.complex128
+
+    def test_rmatvec_matches_hermitian_adjoint(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        x = np.random.default_rng(2).standard_normal(
+            mat.dim
+        ) + 1j * np.random.default_rng(3).standard_normal(mat.dim)
+        y = op.rmatvec(x)
+        np.testing.assert_allclose(y, dense.conj().T @ x, atol=1e-12)
+
+    def test_rmatmat_matches_hermitian_adjoint(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        rng = np.random.default_rng(4)
+        k = 2
+        X = rng.standard_normal((mat.dim, k)) + 1j * rng.standard_normal((mat.dim, k))
+        Y = op.rmatmat(X)
+        np.testing.assert_allclose(Y, dense.conj().T @ X, atol=1e-12)
+
+    def test_matmul_dunder_1d(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        x = np.random.default_rng(5).standard_normal(mat.dim) + 0j
+        np.testing.assert_allclose(op @ x, dense @ x, atol=1e-12)
+
+    def test_matmul_dunder_2d(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        rng = np.random.default_rng(6)
+        X = rng.standard_normal((mat.dim, 4)) + 1j * rng.standard_normal((mat.dim, 4))
+        np.testing.assert_allclose(op @ X, dense @ X, atol=1e-12)
+
+    def test_rmatmul_dunder_1d(self):
+        """``x @ A`` for 1-D ``x`` returns ``A^T @ x`` (plain transpose)."""
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        x = np.random.default_rng(7).standard_normal(
+            mat.dim
+        ) + 1j * np.random.default_rng(8).standard_normal(mat.dim)
+        np.testing.assert_allclose(x @ op, x @ dense, atol=1e-12)
+
+    def test_rmatmul_dunder_2d(self):
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        rng = np.random.default_rng(9)
+        m = 3
+        X = rng.standard_normal((m, mat.dim)) + 1j * rng.standard_normal((m, mat.dim))
+        np.testing.assert_allclose(X @ op, X @ dense, atol=1e-12)
+
+    def test_matvec_wrong_shape_raises(self):
+        mat, coeff, _ = self._make()
+        op = mat.as_linearoperator(coeff)
+        with pytest.raises(ValueError):
+            op.matvec(np.zeros(mat.dim + 1, dtype=np.complex128))
+
+    def test_matmat_wrong_shape_raises(self):
+        mat, coeff, _ = self._make()
+        op = mat.as_linearoperator(coeff)
+        with pytest.raises(ValueError):
+            op.matmat(np.zeros((mat.dim + 1, 2), dtype=np.complex128))
+
+    def test_scipy_eigsh(self):
+        """``scipy.sparse.linalg.eigsh`` works directly on the operator."""
+        mat, coeff, dense = self._make()
+        op = mat.as_linearoperator(coeff)
+        eigvals_dense = np.sort(np.linalg.eigvalsh(dense))
+        eigvals_lo = np.sort(spla.eigsh(op, k=3, which="SA", return_eigenvectors=False))
+        np.testing.assert_allclose(eigvals_lo, eigvals_dense[:3], atol=1e-8)


### PR DESCRIPTION
## Summary

- Extends `PyQMatrixLinearOperator` (`crates/quspin-py/src/linear_operator.rs`) with the SciPy `LinearOperator` duck-typed interface — `shape`, `dtype` (now `numpy.dtype`), `matvec`, `matmat`, `rmatvec`, `rmatmat`, `__matmul__`, `__rmatmul__` — so instances pass directly into `scipy.sparse.linalg.{eigsh, gmres, expm_multiply, …}` without a wrapper layer.
- `rmatvec` / `rmatmat` compute the Hermitian adjoint `A^H @ x` (via `conj(A^T @ conj(x))`), correctly distinguishing from plain transpose for complex matrices.
- `__rmatmul__` returns plain `A^T @ x` to match numpy's `@` semantics; `__array_ufunc__ = None` is set as a classattr so `np.ndarray @ qop` defers to our reflected op instead of falling through numpy's ufunc machinery.
- Closes #108.
- Follow-up issue for dtype-aware matvec (lower precision Krylov vectors): #112.

## Usage

Ground-state via `scipy.sparse.linalg.eigsh` on a small Heisenberg-like Pauli chain:

```python
import numpy as np
import scipy.sparse.linalg as spla

from quspin_rs._rs import PauliOperator, QMatrix, SpinBasis

N = 10
bonds = [[1.0, i, i + 1] for i in range(N - 1)]
op = PauliOperator([("XX", bonds)], [("ZZ", bonds)])

basis = SpinBasis.full(N)
mat = QMatrix.build_pauli(op, basis, np.dtype("complex128"))

# Snapshot the matrix at a specific coupling-constant vector.
coeffs = np.array([1.0 + 0j, 0.5 + 0j], dtype=np.complex128)
lin_op = mat.as_linearoperator(coeffs)

# Pass straight to scipy — no wrapper.
eigvals, eigvecs = spla.eigsh(lin_op, k=3, which="SA")
print(eigvals)
```

The same `lin_op` works with `spla.gmres`, `spla.expm_multiply`, `spla.LinearOperator`-consuming code, and numpy's `@` operator (`lin_op @ x` for 1-D or 2-D `x`).

For a time-dependent Hamiltonian use `Hamiltonian.as_linearoperator(time)` to snapshot at a fixed time before handing off to scipy.

## Breaking change

`QMatrixLinearOperator.dtype` now returns `numpy.dtype('complex128')` instead of the string `"complex128"` (issue #108 option (a)). Pre-alpha, so callers doing `op.dtype == "float64"` should switch to `numpy.dtype` comparisons.

## Test plan

- [x] `just check` — workspace builds cleanly
- [x] `cargo clippy -p quspin-py --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --check`
- [x] `cargo test -p quspin-py` — 3/3 pass
- [x] `just develop` — extension builds
- [x] `uv run pytest python/tests/` — 207 pass (incl. 12 new tests in `python/tests/qmatrix/test_linearoperator.py` covering shape/dtype, matvec/matmat vs dense reference, Hermitian-adjoint correctness of `rmatvec`/`rmatmat`, `op @ x` / `x @ op` for 1-D and 2-D, shape-validation errors, and `scipy.sparse.linalg.eigsh` cross-check against `np.linalg.eigvalsh`)
- [x] Pre-commit hooks pass (black, isort, ruff, pyright, cargo fmt, cargo clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
